### PR TITLE
Pass StringReader instead of strings to CommandDispatcher

### DIFF
--- a/src/main/java/com/mojang/brigadier/ParseResults.java
+++ b/src/main/java/com/mojang/brigadier/ParseResults.java
@@ -10,16 +10,22 @@ import java.util.Map;
 public class ParseResults<S> {
     private final CommandContextBuilder<S> context;
     private final Map<CommandNode<S>, CommandSyntaxException> exceptions;
+    private final int startIndex;
     private final ImmutableStringReader reader;
 
-    public ParseResults(final CommandContextBuilder<S> context, final ImmutableStringReader reader, final Map<CommandNode<S>, CommandSyntaxException> exceptions) {
+    public ParseResults(final CommandContextBuilder<S> context, final int startIndex, final ImmutableStringReader reader, final Map<CommandNode<S>, CommandSyntaxException> exceptions) {
         this.context = context;
+        this.startIndex = startIndex;
         this.reader = reader;
         this.exceptions = exceptions;
     }
 
     public ParseResults(final CommandContextBuilder<S> context) {
-        this(context, new StringReader(""), Collections.emptyMap());
+        this(context, 0, new StringReader(""), Collections.emptyMap());
+    }
+
+    public int getStartIndex() {
+        return startIndex;
     }
 
     public CommandContextBuilder<S> getContext() {

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -120,4 +120,9 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     public Collection<String> getExamples() {
         return type.getExamples();
     }
+
+    @Override
+    public String toString() {
+        return "<argument " + name + ":" + type +">";
+    }
 }

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -118,4 +118,9 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
     public Collection<String> getExamples() {
         return Collections.singleton(literal);
     }
+
+    @Override
+    public String toString() {
+        return "<literal " + literal + ">";
+    }
 }

--- a/src/main/java/com/mojang/brigadier/tree/RootCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/RootCommandNode.java
@@ -62,4 +62,9 @@ public class RootCommandNode<S> extends CommandNode<S> {
     public Collection<String> getExamples() {
         return Collections.emptyList();
     }
+
+    @Override
+    public String toString() {
+        return "<root>";
+    }
 }

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -43,12 +43,27 @@ public class CommandDispatcherTest {
         when(command.run(any())).thenReturn(42);
     }
 
+    private static StringReader inputWithOffset(final String input, final int offset) {
+        final StringReader result = new StringReader(input);
+        result.setCursor(offset);
+        return result;
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testCreateAndExecuteCommand() throws Exception {
         subject.register(literal("foo").executes(command));
 
         assertThat(subject.execute("foo", source), is(42));
+        verify(command).run(any(CommandContext.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCreateAndExecuteOffsetCommand() throws Exception {
+        subject.register(literal("foo").executes(command));
+
+        assertThat(subject.execute(inputWithOffset("/foo", 1), source), is(42));
         verify(command).run(any(CommandContext.class));
     }
 

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherUsagesTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherUsagesTest.java
@@ -102,6 +102,10 @@ public class CommandDispatcherUsagesTest {
         return Iterators.getLast(subject.parse(command, source).getContext().getNodes().keySet().iterator());
     }
 
+    private CommandNode<Object> get(final StringReader command) {
+        return Iterators.getLast(subject.parse(command, source).getContext().getNodes().keySet().iterator());
+    }
+
     @Test
     public void testAllUsage_noCommands() throws Exception {
         subject = new CommandDispatcher<>();
@@ -172,6 +176,20 @@ public class CommandDispatcherUsagesTest {
             .put(get("h 2"), "[2] i ii")
             .put(get("h 3"), "[3]")
             .build()
+        ));
+    }
+
+    @Test
+    public void testSmartUsage_offsetH() throws Exception {
+        final StringReader offsetH = new StringReader("/|/|/h");
+        offsetH.setCursor(5);
+
+        final Map<CommandNode<Object>, String> results = subject.getSmartUsage(get(offsetH), source);
+        assertThat(results, equalTo(ImmutableMap.builder()
+                .put(get("h 1"), "[1] i")
+                .put(get("h 2"), "[2] i ii")
+                .put(get("h 3"), "[3]")
+                .build()
         ));
     }
 }


### PR DESCRIPTION
This is part of cleanup for `/` handling on code (https://github.com/Mojang/Minecraft/commit/6f28ed1e84bdd95a745974bdef5a8b3109675e57).

Also adds `toString` for nodes, for easier debugging.