### PR TITLE
Remove unnecessary Guava usages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.google.guava:guava:21.0'
+    testCompile 'com.google.guava:guava:21.0'
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.hamcrest:hamcrest-library:1.2.1'
     testCompile 'org.mockito:mockito-core:1.8.5'

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -3,9 +3,6 @@
 
 package com.mojang.brigadier;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
@@ -21,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -450,7 +448,7 @@ public class CommandDispatcher<S> {
      * @return array of full usage strings under the target node
      */
     public String[] getAllUsage(final CommandNode<S> node, final S source, final boolean restricted) {
-        final ArrayList<String> result = Lists.newArrayList();
+        final ArrayList<String> result = new ArrayList<>();
         getAllUsage(node, source, result, "", restricted);
         return result.toArray(new String[result.size()]);
     }
@@ -496,7 +494,7 @@ public class CommandDispatcher<S> {
      * @return array of full usage strings under the target node
      */
     public Map<CommandNode<S>, String> getSmartUsage(final CommandNode<S> node, final S source) {
-        final Map<CommandNode<S>, String> result = Maps.newLinkedHashMap();
+        final Map<CommandNode<S>, String> result = new LinkedHashMap<>();
 
         final boolean optional = node.getCommand() != null;
         for (final CommandNode<S> child : node.getChildren()) {
@@ -530,7 +528,7 @@ public class CommandDispatcher<S> {
                         return self + ARGUMENT_SEPARATOR + usage;
                     }
                 } else if (children.size() > 1) {
-                    final Set<String> childUsage = Sets.newLinkedHashSet();
+                    final Set<String> childUsage = new LinkedHashSet<>();
                     for (final CommandNode<S> child : children) {
                         final String usage = getSmartUsage(child, source, childOptional, true);
                         if (usage != null) {
@@ -603,7 +601,7 @@ public class CommandDispatcher<S> {
 
         final CompletableFuture<Suggestions> result = new CompletableFuture<>();
         CompletableFuture.allOf(futures).thenRun(() -> {
-            final List<Suggestions> suggestions = Lists.newArrayList();
+            final List<Suggestions> suggestions = new ArrayList<>();
             for (final CompletableFuture<Suggestions> future : futures) {
                 suggestions.add(future.join());
             }

--- a/src/main/java/com/mojang/brigadier/SingleRedirectModifier.java
+++ b/src/main/java/com/mojang/brigadier/SingleRedirectModifier.java
@@ -6,8 +6,6 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
-import java.util.Collection;
-
 @FunctionalInterface
 public interface SingleRedirectModifier<S> {
     S apply(CommandContext<S> context) throws CommandSyntaxException;

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class CommandContext<S> {
 
-    public static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER = new HashMap<>();
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER = new HashMap<>();
 
     static {
         PRIMITIVE_TO_WRAPPER.put(boolean.class, Boolean.class);

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -3,16 +3,29 @@
 
 package com.mojang.brigadier.context;
 
-import com.google.common.collect.Iterables;
-import com.google.common.primitives.Primitives;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.tree.CommandNode;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class CommandContext<S> {
+
+    public static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER = new HashMap<>();
+
+    static {
+        PRIMITIVE_TO_WRAPPER.put(boolean.class, Boolean.class);
+        PRIMITIVE_TO_WRAPPER.put(byte.class, Byte.class);
+        PRIMITIVE_TO_WRAPPER.put(short.class, Short.class);
+        PRIMITIVE_TO_WRAPPER.put(char.class, Character.class);
+        PRIMITIVE_TO_WRAPPER.put(int.class, Integer.class);
+        PRIMITIVE_TO_WRAPPER.put(long.class, Long.class);
+        PRIMITIVE_TO_WRAPPER.put(float.class, Float.class);
+        PRIMITIVE_TO_WRAPPER.put(double.class, Double.class);
+    }
+
     private final S source;
     private final String input;
     private final Command<S> command;
@@ -73,7 +86,7 @@ public class CommandContext<S> {
         }
 
         final Object result = argument.getResult();
-        if (Primitives.wrap(clazz).isAssignableFrom(result.getClass())) {
+        if (PRIMITIVE_TO_WRAPPER.getOrDefault(clazz, clazz).isAssignableFrom(result.getClass())) {
             return (V) result;
         } else {
             throw new IllegalArgumentException("Argument '" + name + "' is defined as " + result.getClass().getSimpleName() + ", not " + clazz);
@@ -89,7 +102,7 @@ public class CommandContext<S> {
 
         if (!arguments.equals(that.arguments)) return false;
         if (!rootNode.equals(that.rootNode)) return false;
-        if (!Iterables.elementsEqual(nodes, that.nodes)) return false;
+        if (nodes.size() != that.nodes.size() || !nodes.equals(that.nodes)) return false;
         if (command != null ? !command.equals(that.command) : that.command != null) return false;
         if (!source.equals(that.source)) return false;
         if (child != null ? !child.equals(that.child) : that.child != null) return false;

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -4,20 +4,20 @@
 package com.mojang.brigadier.context;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.tree.CommandNode;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public class CommandContextBuilder<S> {
-    private final Map<String, ParsedArgument<S, ?>> arguments = Maps.newLinkedHashMap();
+    private final Map<String, ParsedArgument<S, ?>> arguments = new LinkedHashMap<>();
     private final CommandNode<S> rootNode;
-    private final List<ParsedCommandNode<S>> nodes = Lists.newArrayList();
+    private final List<ParsedCommandNode<S>> nodes = new ArrayList<>();
     private final CommandDispatcher<S> dispatcher;
     private S source;
     private Command<S> command;

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -3,7 +3,6 @@
 
 package com.mojang.brigadier.context;
 
-import com.google.common.collect.Iterables;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.RedirectModifier;
@@ -122,7 +121,7 @@ public class CommandContextBuilder<S> {
                 if (child != null) {
                     return child.findSuggestionContext(cursor);
                 } else if (!nodes.isEmpty()) {
-                    final ParsedCommandNode<S> last = Iterables.getLast(nodes);
+                    final ParsedCommandNode<S> last = nodes.get(nodes.size() - 1);
                     return new SuggestionContext<>(last.getNode(), last.getRange().getEnd() + 1);
                 } else {
                     return new SuggestionContext<>(rootNode, range.getStart());

--- a/src/main/java/com/mojang/brigadier/suggestion/Suggestions.java
+++ b/src/main/java/com/mojang/brigadier/suggestion/Suggestions.java
@@ -3,10 +3,9 @@
 
 package com.mojang.brigadier.suggestion;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.mojang.brigadier.context.StringRange;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -15,7 +14,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class Suggestions {
-    private static final Suggestions EMPTY = new Suggestions(StringRange.at(0), Lists.newArrayList());
+    private static final Suggestions EMPTY = new Suggestions(StringRange.at(0), new ArrayList<>());
 
     private final StringRange range;
     private final List<Suggestion> suggestions;
@@ -92,11 +91,11 @@ public class Suggestions {
             end = Math.max(suggestion.getRange().getEnd(), end);
         }
         final StringRange range = new StringRange(start, end);
-        final Set<Suggestion> texts = Sets.newHashSet();
+        final Set<Suggestion> texts = new HashSet<>();
         for (final Suggestion suggestion : suggestions) {
             texts.add(suggestion.expand(command, range));
         }
-        final List<Suggestion> sorted = Lists.newArrayList(texts);
+        final List<Suggestion> sorted = new ArrayList<>(texts);
         sorted.sort((a, b) -> a.compareToIgnoreCase(b));
         return new Suggestions(range, sorted);
     }

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -174,7 +174,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
 
     @Override
     public int compareTo(final CommandNode<S> o) {
-        if (this instanceof LiteralCommandNode && o instanceof LiteralCommandNode) {
+        if (this instanceof LiteralCommandNode == o instanceof LiteralCommandNode) {
             return getSortedKey().compareTo(o.getSortedKey());
         }
 

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -3,7 +3,6 @@
 
 package com.mojang.brigadier.tree;
 
-import com.google.common.collect.ComparisonChain;
 import com.mojang.brigadier.AmbiguityConsumer;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.RedirectModifier;
@@ -175,11 +174,11 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
 
     @Override
     public int compareTo(final CommandNode<S> o) {
-        return ComparisonChain
-            .start()
-            .compareTrueFirst(this instanceof LiteralCommandNode, o instanceof LiteralCommandNode)
-            .compare(getSortedKey(), o.getSortedKey())
-            .result();
+        if (this instanceof LiteralCommandNode && o instanceof LiteralCommandNode) {
+            return getSortedKey().compareTo(o.getSortedKey());
+        }
+
+        return (o instanceof LiteralCommandNode) ? 1 : -1;
     }
 
     public boolean isFork() {

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -4,8 +4,6 @@
 package com.mojang.brigadier.tree;
 
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.mojang.brigadier.AmbiguityConsumer;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.RedirectModifier;
@@ -19,6 +17,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -27,9 +26,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
-    private Map<String, CommandNode<S>> children = Maps.newLinkedHashMap();
-    private Map<String, LiteralCommandNode<S>> literals = Maps.newLinkedHashMap();
-    private Map<String, ArgumentCommandNode<S, ?>> arguments = Maps.newLinkedHashMap();
+    private Map<String, CommandNode<S>> children = new LinkedHashMap<>();
+    private Map<String, LiteralCommandNode<S>> literals = new LinkedHashMap<>();
+    private Map<String, ArgumentCommandNode<S, ?>> arguments = new LinkedHashMap<>();
     private final Predicate<S> requirement;
     private final CommandNode<S> redirect;
     private final RedirectModifier<S> modifier;
@@ -95,7 +94,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
     }
 
     public void findAmbiguities(final AmbiguityConsumer<S> consumer) {
-        Set<String> matches = Sets.newHashSet();
+        Set<String> matches = new HashSet<>();
 
         for (final CommandNode<S> child : children.values()) {
             for (final CommandNode<S> sibling : children.values()) {
@@ -111,7 +110,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
 
                 if (matches.size() > 0) {
                     consumer.ambiguous(this, child, sibling, matches);
-                    matches = Sets.newHashSet();
+                    matches = new HashSet<>();
                 }
             }
 


### PR DESCRIPTION
Remove unnecessary Guava usages like `Lists.newArrayList()` that can be replace with just `new ArrayList<>()`

https://google.github.io/guava/releases/23.0/api/docs/com/google/common/collect/Lists.html#newArrayList--

Note for Java 7 and later: this method is now unnecessary and should be treated as deprecated. Instead, use the ArrayList constructor directly, taking advantage of the new "diamond" syntax.