### PR TITLE
Fix long argument examples

### DIFF
--- a/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
@@ -84,4 +84,9 @@ public class LongArgumentType implements ArgumentType<Long> {
             return "longArg(" + minimum + ", " + maximum + ")";
         }
     }
+
+    @Override
+    public Collection<String> getExamples() {
+        return EXAMPLES;
+    }
 }


### PR DESCRIPTION
Was missing from `IntegerArgumentType` when I copied from it