### PR TITLE
Add orDefault methods to help with optional arguments

### DIFF
--- a/src/main/java/com/mojang/brigadier/arguments/BoolArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/BoolArgumentType.java
@@ -27,6 +27,10 @@ public class BoolArgumentType implements ArgumentType<Boolean> {
         return context.getArgument(name, Boolean.class);
     }
 
+    public static boolean getBoolOrDefault(final CommandContext<?> context, final String name, final boolean defaultValue) {
+        return context.getArgumentOrDefault(name, defaultValue, Boolean.class);
+    }
+
     @Override
     public Boolean parse(final StringReader reader) throws CommandSyntaxException {
         return reader.readBoolean();

--- a/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
@@ -37,6 +37,10 @@ public class DoubleArgumentType implements ArgumentType<Double> {
         return context.getArgument(name, Double.class);
     }
 
+    public static double getDoubleOrDefault(final CommandContext<?> context, final String name, final double defaultValue) {
+        return context.getArgumentOrDefault(name, defaultValue, Double.class);
+    }
+
     public double getMinimum() {
         return minimum;
     }

--- a/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
@@ -37,6 +37,10 @@ public class FloatArgumentType implements ArgumentType<Float> {
         return context.getArgument(name, Float.class);
     }
 
+    public static float getFloatOrDefault(final CommandContext<?> context, final String name, final float defaultValue) {
+        return context.getArgumentOrDefault(name, defaultValue, Float.class);
+    }
+
     public float getMinimum() {
         return minimum;
     }

--- a/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
@@ -3,6 +3,7 @@
 
 package com.mojang.brigadier.arguments;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -35,6 +36,10 @@ public class IntegerArgumentType implements ArgumentType<Integer> {
 
     public static int getInteger(final CommandContext<?> context, final String name) {
         return context.getArgument(name, int.class);
+    }
+
+    public static int getIntegerOrDefault(final CommandContext<?> context, final String name, final int defaultValue) {
+        return context.getArgumentOrDefault(name, defaultValue, int.class);
     }
 
     public int getMinimum() {

--- a/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
@@ -37,6 +37,10 @@ public class LongArgumentType implements ArgumentType<Long> {
         return context.getArgument(name, long.class);
     }
 
+    public static long getLongOrDefault(final CommandContext<?> context, final String name, final long defaultValue) {
+        return context.getArgumentOrDefault(name, defaultValue, long.class);
+    }
+
     public long getMinimum() {
         return minimum;
     }

--- a/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
@@ -33,6 +33,10 @@ public class StringArgumentType implements ArgumentType<String> {
         return context.getArgument(name, String.class);
     }
 
+    public static String getStringOrDefault(final CommandContext<?> context, final String name, final String defaultValue) {
+        return context.getArgumentOrDefault(name, defaultValue, String.class);
+    }
+
     public StringType getType() {
         return type;
     }

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -80,6 +80,14 @@ public class CommandContext<S> {
         }
     }
 
+    public boolean hasArgument(final String name) {
+        return arguments.containsKey(name);
+    }
+
+    public <V> V getArgumentOrDefault(final String name, final V defaultValue, final Class<V> clazz) {
+        return hasArgument(name) ? getArgument(name, clazz) : defaultValue;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;


### PR DESCRIPTION
Right now there is a problem with lots of consecutive optional arguments; the cleanest way to do it currently is to create a very repetitive list of commands like [this](https://github.com/Earthcomputer/Quick-1.13.1-Carpet/blob/master/src/main/java/quickcarpet/StructureCommand.java). What would be better is to define a `Command<S>` once and pass it to multiple different `.execute()` clauses. Then, each optional argument can have a default value.
Let me give an example of optional arguments with this PR:
```java
Command<S> foo = context -> doFoo(getInteger(context, "bar"), getIntegerOrDefault(context, "baz", 0));
dispatcher.register(literal("foo")
  .then(argument("bar", integer())
    .executes(foo)
    .then(argument("baz")
      .executes(foo))));
```
This has the advantage of removing a lot of code duplication, especially for long chains of optional arguments like the previously linked `/structure` command.

Just as a clarification, it technically *was* possible to emulate the orDefault behaviour by surrounding the context.getArgument() method with a try-catch block, but this was quite verbose and a series of getOrDefault methods is much cleaner in my opinion.