### PR TITLE
Allow scientific notation of numbers and `+` sign

### DIFF
--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -84,7 +84,11 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public static boolean isAllowedNumber(final char c) {
-        return c >= '0' && c <= '9' || c == '.' || c == '-' || c == 'e' || c == 'E' ;
+        return isAllowedInteger(c) || c == '.' || c == 'e' || c == 'E';
+    }
+    
+    public static boolean isAllowedInteger(final char c) {
+        return c >= '0' && c <= '9' || c == '+' || c == '-';
     }
 
     public void skipWhitespace() {
@@ -95,7 +99,7 @@ public class StringReader implements ImmutableStringReader {
 
     public int readInt() throws CommandSyntaxException {
         final int start = cursor;
-        while (canRead() && isAllowedNumber(peek())) {
+        while (canRead() && isAllowedInteger(peek())) {
             skip();
         }
         final String number = string.substring(start, cursor);
@@ -112,7 +116,7 @@ public class StringReader implements ImmutableStringReader {
 
     public long readLong() throws CommandSyntaxException {
         final int start = cursor;
-        while (canRead() && isAllowedNumber(peek())) {
+        while (canRead() && isAllowedInteger(peek())) {
             skip();
         }
         final String number = string.substring(start, cursor);

--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -84,7 +84,7 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public static boolean isAllowedNumber(final char c) {
-        return c >= '0' && c <= '9' || c == '.' || c == '-';
+        return c >= '0' && c <= '9' || c == '.' || c == '-' || c == 'e' || c == 'E' ;
     }
 
     public void skipWhitespace() {

--- a/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
@@ -11,7 +11,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class DoubleArgumentType implements ArgumentType<Double> {
-    private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "-.5", "-1234.56");
+    private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "+1", "-.5", "-1234.56",
+            "1e123", "1E123", "1.2e3", "1.2e-3", "-123.456e-7");
 
     private final double minimum;
     private final double maximum;

--- a/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
@@ -11,7 +11,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class FloatArgumentType implements ArgumentType<Float> {
-    private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "-.5", "-1234.56");
+    private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "+1", "-.5", "-1234.56",
+            "1e123", "1E123", "1.2e3", "1.2e-3", "-123.456e-7");
 
     private final float minimum;
     private final float maximum;

--- a/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class IntegerArgumentType implements ArgumentType<Integer> {
-    private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123");
+    private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123", "+123");
 
     private final int minimum;
     private final int maximum;

--- a/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class LongArgumentType implements ArgumentType<Long> {
-    private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123");
+    private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123", "+123");
 
     private final long minimum;
     private final long maximum;

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -388,33 +388,33 @@ public class StringReaderTest {
     
     @Test
     public void readDouble_explicitPositive() throws Exception {
-        final StringReader reader = new StringReader("+1234567890");
-        assertThat(reader.readDouble(), is(+1234567890.0));
-        assertThat(reader.getRead(), equalTo("+1234567890"));
+        final StringReader reader = new StringReader("+123");
+        assertThat(reader.readDouble(), is(+123.0));
+        assertThat(reader.getRead(), equalTo("+123"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
     
     @Test
     public void readDouble_exponent() throws Exception {
-        final StringReader reader = new StringReader("1.23E4");
-        assertThat(reader.readDouble(), is(12300.0));
-        assertThat(reader.getRead(), equalTo("1.23E4"));
+        final StringReader reader = new StringReader("123e4");
+        assertThat(reader.readDouble(), is(123e4));
+        assertThat(reader.getRead(), equalTo("123e4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
     
     @Test
     public void readDouble_negativeExponent() throws Exception {
-        final StringReader reader = new StringReader("1.23E-4");
-        assertThat(reader.readDouble(), is(0.000123));
-        assertThat(reader.getRead(), equalTo("1.23E-4"));
+        final StringReader reader = new StringReader("123e-4");
+        assertThat(reader.readDouble(), is(123e-4));
+        assertThat(reader.getRead(), equalTo("123e-4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
     
     @Test
     public void readDouble_explicitPositiveExponent() throws Exception {
-        final StringReader reader = new StringReader("1.23E+4");
-        assertThat(reader.readDouble(), is(12300.0));
-        assertThat(reader.getRead(), equalTo("1.23E+4"));
+        final StringReader reader = new StringReader("123e+4");
+        assertThat(reader.readDouble(), is(123e+4));
+        assertThat(reader.getRead(), equalTo("123e+4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 
@@ -480,33 +480,33 @@ public class StringReaderTest {
     
     @Test
     public void readFloat_explicitPositive() throws Exception {
-        final StringReader reader = new StringReader("+1234567890");
-        assertThat(reader.readFloat(), is(+1234567890.0f));
-        assertThat(reader.getRead(), equalTo("+1234567890"));
+        final StringReader reader = new StringReader("+123");
+        assertThat(reader.readFloat(), is(+123.0f));
+        assertThat(reader.getRead(), equalTo("+123"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
     
     @Test
     public void readFloat_exponent() throws Exception {
-        final StringReader reader = new StringReader("1.23E4");
-        assertThat(reader.readFloat(), is(12300.0f));
-        assertThat(reader.getRead(), equalTo("1.23E4"));
+        final StringReader reader = new StringReader("123e4");
+        assertThat(reader.readFloat(), is(123e4f));
+        assertThat(reader.getRead(), equalTo("123e4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
     
     @Test
     public void readFloat_negativeExponent() throws Exception {
-        final StringReader reader = new StringReader("1.23E-4");
-        assertThat(reader.readFloat(), is(0.000123f));
-        assertThat(reader.getRead(), equalTo("1.23E-4"));
+        final StringReader reader = new StringReader("123e-4");
+        assertThat(reader.readFloat(), is(123e-4f));
+        assertThat(reader.getRead(), equalTo("123e-4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
     
     @Test
     public void readFloat_explicitPositiveExponent() throws Exception {
-        final StringReader reader = new StringReader("1.23E+4");
-        assertThat(reader.readFloat(), is(12300.0f));
-        assertThat(reader.getRead(), equalTo("1.23E+4"));
+        final StringReader reader = new StringReader("123e+4");
+        assertThat(reader.readFloat(), is(123e+4f));
+        assertThat(reader.getRead(), equalTo("123e+4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -257,6 +257,14 @@ public class StringReaderTest {
         assertThat(reader.getRead(), equalTo("-1234567890"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
+    
+    @Test
+    public void readInt_explicitPositive() throws Exception {
+        final StringReader reader = new StringReader("+1234567890");
+        assertThat(reader.readInt(), is(+1234567890));
+        assertThat(reader.getRead(), equalTo("+1234567890"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
 
     @Test
     public void readInt_invalid() throws Exception {
@@ -307,6 +315,14 @@ public class StringReaderTest {
         final StringReader reader = new StringReader("-1234567890");
         assertThat(reader.readLong(), is(-1234567890L));
         assertThat(reader.getRead(), equalTo("-1234567890"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
+    public void readLong_explicitPositive() throws Exception {
+        final StringReader reader = new StringReader("+1234567890");
+        assertThat(reader.readLong(), is(+1234567890L));
+        assertThat(reader.getRead(), equalTo("+1234567890"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 
@@ -371,6 +387,14 @@ public class StringReaderTest {
     }
     
     @Test
+    public void readDouble_explicitPositive() throws Exception {
+        final StringReader reader = new StringReader("+1234567890");
+        assertThat(reader.readDouble(), is(+1234567890.0));
+        assertThat(reader.getRead(), equalTo("+1234567890"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
     public void readDouble_exponent() throws Exception {
         final StringReader reader = new StringReader("1.23E4");
         assertThat(reader.readDouble(), is(12300.0));
@@ -383,6 +407,14 @@ public class StringReaderTest {
         final StringReader reader = new StringReader("1.23E-4");
         assertThat(reader.readDouble(), is(0.000123));
         assertThat(reader.getRead(), equalTo("1.23E-4"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
+    public void readDouble_explicitPositiveExponent() throws Exception {
+        final StringReader reader = new StringReader("1.23E+4");
+        assertThat(reader.readDouble(), is(12300.0));
+        assertThat(reader.getRead(), equalTo("1.23E+4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 
@@ -447,6 +479,14 @@ public class StringReaderTest {
     }
     
     @Test
+    public void readFloat_explicitPositive() throws Exception {
+        final StringReader reader = new StringReader("+1234567890");
+        assertThat(reader.readFloat(), is(+1234567890.0f));
+        assertThat(reader.getRead(), equalTo("+1234567890"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
     public void readFloat_exponent() throws Exception {
         final StringReader reader = new StringReader("1.23E4");
         assertThat(reader.readFloat(), is(12300.0f));
@@ -459,6 +499,14 @@ public class StringReaderTest {
         final StringReader reader = new StringReader("1.23E-4");
         assertThat(reader.readFloat(), is(0.000123f));
         assertThat(reader.getRead(), equalTo("1.23E-4"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
+    public void readFloat_explicitPositiveExponent() throws Exception {
+        final StringReader reader = new StringReader("1.23E+4");
+        assertThat(reader.readFloat(), is(12300.0f));
+        assertThat(reader.getRead(), equalTo("1.23E+4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -369,6 +369,22 @@ public class StringReaderTest {
         assertThat(reader.getRead(), equalTo("-123"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
+    
+    @Test
+    public void readDouble_exponent() throws Exception {
+        final StringReader reader = new StringReader("1.23E4");
+        assertThat(reader.readDouble(), is(12300.0));
+        assertThat(reader.getRead(), equalTo("1.23E4"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
+    public void readDouble_negativeExponent() throws Exception {
+        final StringReader reader = new StringReader("1.23E-4");
+        assertThat(reader.readDouble(), is(0.000123));
+        assertThat(reader.getRead(), equalTo("1.23E-4"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
 
     @Test
     public void readDouble_invalid() throws Exception {
@@ -421,12 +437,28 @@ public class StringReaderTest {
         assertThat(reader.getRead(), equalTo("12.34"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
-
+    
     @Test
     public void readFloat_negative() throws Exception {
         final StringReader reader = new StringReader("-123");
         assertThat(reader.readFloat(), is(-123.0f));
         assertThat(reader.getRead(), equalTo("-123"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
+    public void readFloat_exponent() throws Exception {
+        final StringReader reader = new StringReader("1.23E4");
+        assertThat(reader.readFloat(), is(12300.0f));
+        assertThat(reader.getRead(), equalTo("1.23E4"));
+        assertThat(reader.getRemaining(), equalTo(""));
+    }
+    
+    @Test
+    public void readFloat_negativeExponent() throws Exception {
+        final StringReader reader = new StringReader("1.23E-4");
+        assertThat(reader.readFloat(), is(0.000123f));
+        assertThat(reader.getRead(), equalTo("1.23E-4"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -469,7 +469,7 @@ public class StringReaderTest {
         assertThat(reader.getRead(), equalTo("12.34"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
-    
+
     @Test
     public void readFloat_negative() throws Exception {
         final StringReader reader = new StringReader("-123");


### PR DESCRIPTION
This is a simple fix to allow for scientific notation of floating point numbers.
This commit would also fix the following ticket on the Minecraft Bug tracker: https://bugs.mojang.com/browse/MC-130925