### PR TITLE
Add some javadoc comments to give a rough outline

### DIFF
--- a/src/main/java/com/mojang/brigadier/AmbiguityConsumer.java
+++ b/src/main/java/com/mojang/brigadier/AmbiguityConsumer.java
@@ -7,7 +7,22 @@ import com.mojang.brigadier.tree.CommandNode;
 
 import java.util.Collection;
 
+/**
+ * A consumer that is notified of found ambiguities in the command tree.
+ *
+ * @param <S> the command source
+ * @see CommandDispatcher#findAmbiguities
+ */
 @FunctionalInterface
 public interface AmbiguityConsumer<S> {
+
+    /**
+     * Invoked when ambiguities are detected.
+     *
+     * @param parent the parent command of the command that is ambiguous
+     * @param child the first command that is ambiguous
+     * @param sibling the second command that is ambiguous
+     * @param inputs the inputs for which they both matched and therefore were ambiguous
+     */
     void ambiguous(final CommandNode<S> parent, final CommandNode<S> child, final CommandNode<S> sibling, final Collection<String> inputs);
 }

--- a/src/main/java/com/mojang/brigadier/Command.java
+++ b/src/main/java/com/mojang/brigadier/Command.java
@@ -6,9 +6,30 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
+/**
+ * The functional interface actually representing a command to execute.
+ * <p>
+ * This interface represents the code that will be run, when the command is executed.
+ *
+ * @param <S> the type of the command source this command will be called with
+ */
 @FunctionalInterface
 public interface Command<S> {
+    /**
+     * A static constant you can use when the command completed successfully.
+     * <p>
+     * As the return value means what you want it to mean, this is merely a suggestion to make the code a bit more
+     * expressive, if you follow it.
+     */
     int SINGLE_SUCCESS = 1;
 
+    /**
+     * Executes the command using the given {@link CommandContext} to supply information to the command.
+     *
+     * @param context the command context to use for supplying all information the command will need
+     * @return the result of executing the command. The value is arbitrary, though {@link #SINGLE_SUCCESS} is a
+     * suggestion
+     * @throws CommandSyntaxException TODO: Why does it throw a <strong>Syntax</strong> exception here?
+     */
     int run(CommandContext<S> context) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -6,6 +6,7 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
+import com.mojang.brigadier.context.StringRange;
 import com.mojang.brigadier.context.SuggestionContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestions;
@@ -435,8 +436,8 @@ public class CommandDispatcher<S> {
      * listed as multiple entries: the parent node, and the child nodes.
      * For example, a required literal "foo" followed by an optional param "int" will be two nodes:</p>
      * <ul>
-     *     <li>{@code foo}</li>
-     *     <li>{@code foo <int>}</li>
+     * <li>{@code foo}</li>
+     * <li>{@code foo <int>}</li>
      * </ul>
      *
      * <p>The path to the specified node will <b>not</b> be prepended to the output, as there can theoretically be many
@@ -481,7 +482,7 @@ public class CommandDispatcher<S> {
      * These forms may be mixed and matched to provide as much information about the child nodes as it can, without being too verbose.
      * For example, a required literal "foo" followed by an optional param "int" can be compressed into one string:</p>
      * <ul>
-     *     <li>{@code foo [<int>]}</li>
+     * <li>{@code foo [<int>]}</li>
      * </ul>
      *
      * <p>The path to the specified node will <b>not</b> be prepended to the output, as there can theoretically be many
@@ -579,6 +580,22 @@ public class CommandDispatcher<S> {
         return getCompletionSuggestions(parse, parse.getReader().getTotalLength());
     }
 
+    /**
+     * Gets suggestions for a parsed input string on what comes next, checking from the given cursor position.
+     *
+     * <p>As it is ultimately up to custom argument types to provide suggestions, it may be an asynchronous operation,
+     * for example getting in-game data or player names etc. As such, this method returns a future and no guarantees
+     * are made to when or how the future completes.</p>
+     *
+     * <p>The suggestions provided will be in the context of the end of the parsed input string, but may suggest
+     * new or replacement strings for earlier in the input string. For example, if the end of the string was
+     * {@code foobar} but an argument preferred it to be {@code minecraft:foobar}, it will suggest a replacement for that
+     * whole segment of the input.</p>
+     *
+     * @param parse the result of a {@link #parse(StringReader, Object)}
+     * @param cursor the index to fetch suggestions for
+     * @return a future that will eventually resolve into a {@link Suggestions} object
+     */
     public CompletableFuture<Suggestions> getCompletionSuggestions(final ParseResults<S> parse, int cursor) {
         final CommandContextBuilder<S> context = parse.getContext();
 

--- a/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
+++ b/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
@@ -3,24 +3,82 @@
 
 package com.mojang.brigadier;
 
+/**
+ * Basically a string reader that can not be modified.
+ */
 public interface ImmutableStringReader {
+    /**
+     * Returns the full input string.
+     *
+     * @return the full input string
+     */
     String getString();
 
+    /**
+     * Returns the remaining length, so the distance from the cursor to the end of the input.
+     *
+     * @return the remaining length, so the distance from the cursor to the end of the input
+     */
     int getRemainingLength();
 
+    /**
+     * Returns the total length of the input.
+     *
+     * @return the total length of the input
+     */
     int getTotalLength();
 
+    /**
+     * Returns the current cursor position.
+     *
+     * @return the current cursor position.
+     */
     int getCursor();
 
+    /**
+     * Returns the part of the input that was already read.
+     *
+     * @return the part of the input that was already read
+     */
     String getRead();
 
+    /**
+     * Returns the part of the input that was not yet read.
+     *
+     * @return the part of the input that was not yet read
+     */
     String getRemaining();
 
+    /**
+     * Checks if the reader has enough input to read {@code length} more characters.
+     *
+     * @param length the amount of characters to read
+     * @return true of the reader has enough input to read {@code length} more characters.
+     */
     boolean canRead(int length);
 
+    /**
+     * Checks if the reader can read at least one more character.
+     *
+     * @return true if the reader can read at least one more character
+     * @see #canRead(int)
+     */
     boolean canRead();
 
+    /**
+     * Returns the next character but without consuming it (so the cursor stays at its current position).
+     *
+     * @return the next character
+     * @see #peek(int)
+     */
     char peek();
 
+    /**
+     * Returns the character {@code offset} places from now without consuming it (so the cursor stays at its current
+     * position).
+     *
+     * @param offset the offset of the character to peek at
+     * @return the character {@code offset} places from now
+     */
     char peek(int offset);
 }

--- a/src/main/java/com/mojang/brigadier/LiteralMessage.java
+++ b/src/main/java/com/mojang/brigadier/LiteralMessage.java
@@ -3,9 +3,17 @@
 
 package com.mojang.brigadier;
 
+/**
+ * A {@link Message} that has a literal string it returns.
+ */
 public class LiteralMessage implements Message {
     private final String string;
 
+    /**
+     * Creates a new {@link LiteralMessage} returning the given string.
+     *
+     * @param string the string to return
+     */
     public LiteralMessage(final String string) {
         this.string = string;
     }

--- a/src/main/java/com/mojang/brigadier/Message.java
+++ b/src/main/java/com/mojang/brigadier/Message.java
@@ -3,6 +3,15 @@
 
 package com.mojang.brigadier;
 
+/**
+ * An abstract notion of a message that can be displayed to a user.
+ */
 public interface Message {
+
+    /**
+     * Returns the content of the message.
+     *
+     * @return the content of the message
+     */
     String getString();
 }

--- a/src/main/java/com/mojang/brigadier/ParseResults.java
+++ b/src/main/java/com/mojang/brigadier/ParseResults.java
@@ -3,6 +3,7 @@
 
 package com.mojang.brigadier;
 
+import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.CommandNode;
@@ -10,6 +11,11 @@ import com.mojang.brigadier.tree.CommandNode;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Consolidates the results of parsing a command in an object.
+ *
+ * @param <S> the type of the command source
+ */
 public class ParseResults<S> {
     private final CommandContextBuilder<S> context;
     private final Map<CommandNode<S>, CommandSyntaxException> exceptions;
@@ -25,14 +31,29 @@ public class ParseResults<S> {
         this(context, new StringReader(""), Collections.emptyMap());
     }
 
+    /**
+     * The {@link CommandContext} that was created.
+     *
+     * @return the created command context
+     */
     public CommandContextBuilder<S> getContext() {
         return context;
     }
 
+    /**
+     * An immutable version of the string reader that was used to read the input
+     *
+     * @return the string reader that was used to read the input
+     */
     public ImmutableStringReader getReader() {
         return reader;
     }
 
+    /**
+     * Returns all exceptions that occurred while parsing together with the node that caused them.
+     *
+     * @return all exceptions that occurred while parsing together with the node that caused them
+     */
     public Map<CommandNode<S>, CommandSyntaxException> getExceptions() {
         return exceptions;
     }

--- a/src/main/java/com/mojang/brigadier/RedirectModifier.java
+++ b/src/main/java/com/mojang/brigadier/RedirectModifier.java
@@ -8,7 +8,23 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import java.util.Collection;
 
+/**
+ * A redirect modifier to apply when a command is redirected and/or forked.
+ * <p>
+ * A redirect modifier takes a command context with a single command source and returns a collection of multiple
+ * command sources. The target command is then invoked for each of the returned command sources.
+ *
+ * @param <S> the type of the command source
+ */
 @FunctionalInterface
 public interface RedirectModifier<S> {
+
+    /**
+     * Applies the modifier to the context, so it creates a list of command sources to invoke the target command for.
+     *
+     * @param context the context to base it on
+     * @return a list with command sources to invoke the command for
+     * @throws CommandSyntaxException if an error occurred
+     */
     Collection<S> apply(CommandContext<S> context) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/ResultConsumer.java
+++ b/src/main/java/com/mojang/brigadier/ResultConsumer.java
@@ -5,7 +5,19 @@ package com.mojang.brigadier;
 
 import com.mojang.brigadier.context.CommandContext;
 
+/**
+ * A consumer that is called by the {@link CommandDispatcher} whenever a command completed.
+ *
+ * @param <S> the type of the command source
+ */
 @FunctionalInterface
 public interface ResultConsumer<S> {
+    /**
+     * Invoked when a command execution completed, either normally or abnormally.
+     *
+     * @param context the command context of the execution
+     * @param success whether the command completed successfully
+     * @param result the result of the command, if it completed successfully
+     */
     void onCommandComplete(CommandContext<S> context, boolean success, int result);
 }

--- a/src/main/java/com/mojang/brigadier/SingleRedirectModifier.java
+++ b/src/main/java/com/mojang/brigadier/SingleRedirectModifier.java
@@ -6,7 +6,21 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
+/**
+ * Basically a {@link RedirectModifier} (though no subtype) that only converts to a single command source-
+ *
+ * @param <S> the type of the command source
+ */
 @FunctionalInterface
 public interface SingleRedirectModifier<S> {
+
+    /**
+     * Applies the redirect modifier to the command context, returning the new command source to use for invoking the
+     * command.
+     *
+     * @param context the command context to base it on
+     * @return the new command source to invoke the command for
+     * @throws CommandSyntaxException if an error occurred
+     */
     S apply(CommandContext<S> context) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
@@ -3,23 +3,65 @@
 
 package com.mojang.brigadier.arguments;
 
+import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * An argument an {@link ArgumentCommandNode} can take as its argument.
+ * <p>
+ * As different commands need different arguments (string, integer, long, double,…), this interface provides a
+ * way to define parsers for each of them.
+ *
+ * @param <T> the type of the argument
+ */
 public interface ArgumentType<T> {
+
+    /**
+     * Parses the given {@link StringReader} to an instance of this argument's generic type.
+     *
+     * @param reader the read to read from
+     * @return the parsed argument. If this is an {@code ArgumentType<Integer>} this would return an Integer.
+     * @throws CommandSyntaxException if the argument is malformed
+     */
     T parse(StringReader reader) throws CommandSyntaxException;
 
+    /**
+     * Gets suggestions for a parsed input string on what comes next.
+     *
+     * <p>As it is ultimately up to custom argument types to provide suggestions, it may be an asynchronous operation,
+     * for example getting in-game data or player names etc. As such, this method returns a future and no guarantees
+     * are made to when or how the future completes.</p>
+     *
+     * <p>The suggestions provided will be in the context of the end of the parsed input string, but may suggest
+     * new or replacement strings for earlier in the input string. For example, if the end of the string was
+     * {@code foobar} but an argument preferred it to be {@code minecraft:foobar}, it will suggest a replacement for that
+     * whole segment of the input.</p>
+     *
+     * @param context the context to get them for
+     * @param builder the suggestions builder to add them to
+     * @return a future that will eventually resolve into a {@link Suggestions} object
+     * @implSpec The default implementation simple returns an empty list.
+     */
     default <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
         return Suggestions.empty();
     }
 
+    /**
+     * Provides examples of valid arguments that are used by
+     * {@link CommandDispatcher#findAmbiguities}  to find ambiguities.
+     *
+     * @return a list with a few examples for valid type arguments
+     * @implSpec The default implementation returns an emtpy list.
+     */
     default Collection<String> getExamples() {
         return Collections.emptyList();
     }

--- a/src/main/java/com/mojang/brigadier/arguments/BoolArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/BoolArgumentType.java
@@ -13,16 +13,37 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * An {@link ArgumentType} that parses booleans.
+ */
 public class BoolArgumentType implements ArgumentType<Boolean> {
     private static final Collection<String> EXAMPLES = Arrays.asList("true", "false");
 
     private BoolArgumentType() {
     }
 
+    /**
+     * A static factory method provides as a simple way to get instances.
+     * <p>
+     * It is recommended to statically import this method to provide an interface similar to:<br>
+     * <code>
+     * argument("name", bool())
+     * </code>
+     *
+     * @return an instance of this class
+     */
     public static BoolArgumentType bool() {
         return new BoolArgumentType();
     }
 
+    /**
+     * Retrieves the argument with the given name from the context and casts it to a boolean.
+     *
+     * @param context the context to get the argument from, calls {@link CommandContext#getArgument}
+     * @param name the name of the argument to retrieve
+     * @return the argument as a boolean
+     * @see CommandContext#getArgument
+     */
     public static boolean getBool(final CommandContext<?> context, final String name) {
         return context.getArgument(name, Boolean.class);
     }

--- a/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
@@ -10,6 +10,12 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 
+/**
+ * An {@link ArgumentType} that parses doubles.
+ * <p>
+ * Allows for numbers in the following format:<br>
+ * {@literal (-)?\d+('.'\d+)*}
+ */
 public class DoubleArgumentType implements ArgumentType<Double> {
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "-.5", "-1234.56");
 
@@ -21,26 +27,62 @@ public class DoubleArgumentType implements ArgumentType<Double> {
         this.maximum = maximum;
     }
 
+    /**
+     * A factory method intended for use via a static import.
+     *
+     * @return an instance of this argument type
+     */
     public static DoubleArgumentType doubleArg() {
         return doubleArg(-Double.MAX_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces a minimum value.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static DoubleArgumentType doubleArg(final double min) {
         return doubleArg(min, Double.MAX_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces that the number lies within a given range.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @param max the maximal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static DoubleArgumentType doubleArg(final double min, final double max) {
         return new DoubleArgumentType(min, max);
     }
 
+    /**
+     * Retrieves the argument with the given name from the context and casts it to a double.
+     *
+     * @param context the context to get the argument from, calls {@link CommandContext#getArgument}
+     * @param name the name of the argument to retrieve
+     * @return the argument as a double
+     * @see CommandContext#getArgument
+     */
     public static double getDouble(final CommandContext<?> context, final String name) {
         return context.getArgument(name, Double.class);
     }
 
+    /**
+     * The minimum value an argument is allowed to be (inclusive).
+     *
+     * @return the minimum value an argument is allowed to be (inclusive).
+     */
     public double getMinimum() {
         return minimum;
     }
 
+    /**
+     * The maximal value an argument is allowed to be (inclusive).
+     *
+     * @return the maximal value an argument is allowed to be (inclusive).
+     */
     public double getMaximum() {
         return maximum;
     }

--- a/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
@@ -10,6 +10,12 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 
+/**
+ * An {@link ArgumentType} that parses floats.
+ * <p>
+ * Allows for numbers in the following format:<br>
+ * {@literal (-)?\d+('.'\d+)*}
+ */
 public class FloatArgumentType implements ArgumentType<Float> {
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "-.5", "-1234.56");
 
@@ -21,26 +27,62 @@ public class FloatArgumentType implements ArgumentType<Float> {
         this.maximum = maximum;
     }
 
+    /**
+     * A factory method intended for use via a static import.
+     *
+     * @return an instance of this argument type
+     */
     public static FloatArgumentType floatArg() {
         return floatArg(-Float.MAX_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces a minimum value.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static FloatArgumentType floatArg(final float min) {
         return floatArg(min, Float.MAX_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces that the number lies within a given range.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @param max the maximal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static FloatArgumentType floatArg(final float min, final float max) {
         return new FloatArgumentType(min, max);
     }
 
+    /**
+     * Retrieves the argument with the given name from the context and casts it to a float.
+     *
+     * @param context the context to get the argument from, calls {@link CommandContext#getArgument}
+     * @param name the name of the argument to retrieve
+     * @return the argument as a float
+     * @see CommandContext#getArgument
+     */
     public static float getFloat(final CommandContext<?> context, final String name) {
         return context.getArgument(name, Float.class);
     }
 
+    /**
+     * The minimum value an argument is allowed to be (inclusive).
+     *
+     * @return the minimum value an argument is allowed to be (inclusive).
+     */
     public float getMinimum() {
         return minimum;
     }
 
+    /**
+     * The maximal value an argument is allowed to be (inclusive).
+     *
+     * @return the maximal value an argument is allowed to be (inclusive).
+     */
     public float getMaximum() {
         return maximum;
     }

--- a/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
@@ -10,6 +10,12 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 
+/**
+ * An {@link ArgumentType} that parses integers.
+ * <p>
+ * Allows for numbers in the following format:<br>
+ * {@literal (-)?\d+}
+ */
 public class IntegerArgumentType implements ArgumentType<Integer> {
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123");
 
@@ -21,26 +27,62 @@ public class IntegerArgumentType implements ArgumentType<Integer> {
         this.maximum = maximum;
     }
 
+    /**
+     * A factory method intended for use via a static import.
+     *
+     * @return an instance of this argument type
+     */
     public static IntegerArgumentType integer() {
         return integer(Integer.MIN_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces a minimum value.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static IntegerArgumentType integer(final int min) {
         return integer(min, Integer.MAX_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces that the number lies within a given range.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @param max the maximal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static IntegerArgumentType integer(final int min, final int max) {
         return new IntegerArgumentType(min, max);
     }
 
+    /**
+     * Retrieves the argument with the given name from the context and casts it to an integer.
+     *
+     * @param context the context to get the argument from, calls {@link CommandContext#getArgument}
+     * @param name the name of the argument to retrieve
+     * @return the argument as an integer
+     * @see CommandContext#getArgument
+     */
     public static int getInteger(final CommandContext<?> context, final String name) {
         return context.getArgument(name, int.class);
     }
 
+    /**
+     * The minimum value an argument is allowed to be (inclusive).
+     *
+     * @return the minimum value an argument is allowed to be (inclusive).
+     */
     public int getMinimum() {
         return minimum;
     }
 
+    /**
+     * The maximal value an argument is allowed to be (inclusive).
+     *
+     * @return the maximal value an argument is allowed to be (inclusive).
+     */
     public int getMaximum() {
         return maximum;
     }

--- a/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
@@ -10,6 +10,12 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 
+/**
+ * An {@link ArgumentType} that parses longs.
+ * <p>
+ * Allows for numbers in the following format:<br>
+ * {@literal (-)?\d+}
+ */
 public class LongArgumentType implements ArgumentType<Long> {
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123");
 
@@ -21,26 +27,62 @@ public class LongArgumentType implements ArgumentType<Long> {
         this.maximum = maximum;
     }
 
+    /**
+     * A factory method intended for use via a static import.
+     *
+     * @return an instance of this argument type
+     */
     public static LongArgumentType longArg() {
         return longArg(Long.MIN_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces a minimum value.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static LongArgumentType longArg(final long min) {
         return longArg(min, Long.MAX_VALUE);
     }
 
+    /**
+     * A factory method intended for use via a static import which enforces that the number lies within a given range.
+     *
+     * @param min the minimal value it needs to be in order to be a valid argument. Inclusive.
+     * @param max the maximal value it needs to be in order to be a valid argument. Inclusive.
+     * @return an instance of this argument type
+     */
     public static LongArgumentType longArg(final long min, final long max) {
         return new LongArgumentType(min, max);
     }
 
+    /**
+     * Retrieves the argument with the given name from the context and casts it to a long.
+     *
+     * @param context the context to get the argument from, calls {@link CommandContext#getArgument}
+     * @param name the name of the argument to retrieve
+     * @return the argument as a long
+     * @see CommandContext#getArgument
+     */
     public static long getLong(final CommandContext<?> context, final String name) {
         return context.getArgument(name, long.class);
     }
 
+    /**
+     * The minimum value an argument is allowed to be (inclusive).
+     *
+     * @return the minimum value an argument is allowed to be (inclusive).
+     */
     public long getMinimum() {
         return minimum;
     }
 
+    /**
+     * The maximal value an argument is allowed to be (inclusive).
+     *
+     * @return the maximal value an argument is allowed to be (inclusive).
+     */
     public long getMaximum() {
         return maximum;
     }

--- a/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
@@ -10,6 +10,9 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 
+/**
+ * An {@link ArgumentType} that parses strings.
+ */
 public class StringArgumentType implements ArgumentType<String> {
     private final StringType type;
 
@@ -17,22 +20,50 @@ public class StringArgumentType implements ArgumentType<String> {
         this.type = type;
     }
 
+    /**
+     * An instance of this argument type that only parses a single word, i.e. up until a space.
+     *
+     * @return an instance of this argument type parsing a single word.
+     */
     public static StringArgumentType word() {
         return new StringArgumentType(StringType.SINGLE_WORD);
     }
 
+    /**
+     * An instance of this argument type that only parses a single word or a quoted string.
+     *
+     * @return an instance of this argument type parsing a word or quoted string.
+     */
     public static StringArgumentType string() {
         return new StringArgumentType(StringType.QUOTABLE_PHRASE);
     }
 
+    /**
+     * An instance of this argument type that only parses everything up until the end of the input.
+     *
+     * @return an instance of this argument type parsing everything until the end of the input
+     */
     public static StringArgumentType greedyString() {
         return new StringArgumentType(StringType.GREEDY_PHRASE);
     }
 
+    /**
+     * Retrieves the argument with the given name from the context and casts it to an string.
+     *
+     * @param context the context to get the argument from, calls {@link CommandContext#getArgument}
+     * @param name the name of the argument to retrieve
+     * @return the argument as an string
+     * @see CommandContext#getArgument
+     */
     public static String getString(final CommandContext<?> context, final String name) {
         return context.getArgument(name, String.class);
     }
 
+    /**
+     * The type of string this argument parses.
+     *
+     * @return the {@link StringType} this argument parses
+     */
     public StringType getType() {
         return type;
     }
@@ -60,6 +91,24 @@ public class StringArgumentType implements ArgumentType<String> {
         return type.getExamples();
     }
 
+    /**
+     * Converts a String to phrase {@link StringType#QUOTABLE_PHRASE} would match.
+     * <p>
+     * This will escape all characters that can not appear in an unquoted and wrap the string in quotes, if required.
+     * More specifically, this will always wrap the string in quotes, if <em>any</em> character in it needs to be escaped.
+     * <p>
+     * <p>
+     * Some sample in and outputs:
+     * <ul>
+     * <li>{@code hey} to {@code hey}</li>
+     * <li>{@code hey you} to {@code "hey you"}</li>
+     * <li>{@code "hello"} to {@code "\"hello\""}</li>
+     * <li>{@code \} to {@code "\\"}</li>
+     * </ul>
+     *
+     * @param input the input to escape
+     * @return the escaped output ready to be parsed by {@link StringType#QUOTABLE_PHRASE}
+     */
     public static String escapeIfRequired(final String input) {
         for (final char c : input.toCharArray()) {
             if (!StringReader.isAllowedInUnquotedString(c)) {
@@ -84,10 +133,26 @@ public class StringArgumentType implements ArgumentType<String> {
         return result.toString();
     }
 
+    /**
+     * The type of phrase that is matched by {@link StringArgumentType}.
+     */
     public enum StringType {
+        /**
+         * Matches a single word, optionally concatenated with underscores.
+         * Can contain the following characters: <br>
+         * {@code [a-zA-Z0-9_\-.+]}
+         */
         SINGLE_WORD("word", "words_with_underscores"),
+        /**
+         * Matches what {@link #SINGLE_WORD} matches or a phrase surrounded by quotes ({@literal "}), optionally
+         * containing escaped characters.
+         */
         QUOTABLE_PHRASE("\"quoted phrase\"", "word", "\"\""),
-        GREEDY_PHRASE("word", "words with spaces", "\"and symbols\""),;
+        /**
+         * Just greedily matches the whole available input.
+         */
+        GREEDY_PHRASE("word", "words with spaces", "\"and symbols\""),
+        ;
 
         private final Collection<String> examples;
 
@@ -95,6 +160,12 @@ public class StringArgumentType implements ArgumentType<String> {
             this.examples = Arrays.asList(examples);
         }
 
+        /**
+         * Returns some examples that define this type, which are used to detect ambiguities.
+         *
+         * @return some examples that define this type, which are used to detect ambiguities.
+         * @see ArgumentType#getExamples()
+         */
         public Collection<String> getExamples() {
             return examples;
         }

--- a/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
@@ -6,13 +6,32 @@ package com.mojang.brigadier.builder;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 
+/**
+ * An {@link ArgumentBuilder} for a {@link LiteralCommandNode} that is triggered by a literal (i.e. fixed) keyword.
+ * <p>
+ * An example would be a command like "ping", that is identified by its keyword.
+ *
+ * @param <S> the type of the command source
+ */
 public class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumentBuilder<S>> {
     private final String literal;
 
+    /**
+     * Creates a new {@link LiteralArgumentBuilder} with the given literal
+     *
+     * @param literal the literal that identifies the built command
+     */
     protected LiteralArgumentBuilder(final String literal) {
         this.literal = literal;
     }
 
+    /**
+     * A factory method to create a new builder for a literal command node
+     *
+     * @param name the literal the built command should be identified by
+     * @param <S> the type of the command source
+     * @return the created {@link LiteralArgumentBuilder}
+     */
     public static <S> LiteralArgumentBuilder<S> literal(final String name) {
         return new LiteralArgumentBuilder<>(name);
     }
@@ -22,6 +41,11 @@ public class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumen
         return this;
     }
 
+    /**
+     * Returns the literal that the built command will be identified by.
+     *
+     * @return the literal that the built command will be identified by.
+     */
     public String getLiteral() {
         return literal;
     }

--- a/src/main/java/com/mojang/brigadier/builder/RequiredArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/RequiredArgumentBuilder.java
@@ -4,10 +4,25 @@
 package com.mojang.brigadier.builder;
 
 import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
 
+/**
+ * An {@link ArgumentBuilder} for a {@link ArgumentCommandNode} that is triggered by an argument, like a number.
+ * <p>
+ * The type of the argument is set via an {@link ArgumentType}, which takes care of parsing the stringified argument
+ * passed by users.
+ * <p>
+ * <br>A short <strong>example</strong>:
+ * <br>A subcommand for a delete command, taking the number of messages to delete. The {@link ArgumentType} would be an
+ * {@link IntegerArgumentType} then and the built command would parse things like {@literal "20"} or {@literal "-230"}.
+ *
+ * @param <S> the type of the command source
+ * @param <T> the {@link ArgumentType} the built command will use
+ */
 public class RequiredArgumentBuilder<S, T> extends ArgumentBuilder<S, RequiredArgumentBuilder<S, T>> {
     private final String name;
     private final ArgumentType<T> type;
@@ -18,15 +33,39 @@ public class RequiredArgumentBuilder<S, T> extends ArgumentBuilder<S, RequiredAr
         this.type = type;
     }
 
+    /**
+     * Returns a {@link RequiredArgumentBuilder} whose argument has the given name and is of the given
+     * {@link ArgumentType}.
+     * <p>
+     * This method is intended for static importing, so you can just use {@code argument(<name>, <type>)"} in your code.
+     *
+     * @param name the name of the argument. Used with {@link CommandContext#getArgument} to retrieve the parsed
+     * argument out of a {@link CommandContext}
+     * @param type the {@link ArgumentType} this command takes
+     * @param <S> the type of the command source
+     * @param <T> the java type of the argument this command takes
+     * @return a {@link RequiredArgumentBuilder} with a given name and argument type
+     */
     public static <S, T> RequiredArgumentBuilder<S, T> argument(final String name, final ArgumentType<T> type) {
         return new RequiredArgumentBuilder<>(name, type);
     }
 
+    /**
+     * Sets the {@link SuggestionProvider} that provides the user with suggestions about what the next value could be.
+     *
+     * @param provider the {@link SuggestionProvider} to use
+     * @return this argument builder
+     */
     public RequiredArgumentBuilder<S, T> suggests(final SuggestionProvider<S> provider) {
         this.suggestionsProvider = provider;
         return getThis();
     }
 
+    /**
+     * Returns the {@link SuggestionProvider} the command uses to advice the user on possible completions.
+     *
+     * @return the registered {@link SuggestionProvider} or null if none
+     */
     public SuggestionProvider<S> getSuggestionsProvider() {
         return suggestionsProvider;
     }
@@ -36,14 +75,27 @@ public class RequiredArgumentBuilder<S, T> extends ArgumentBuilder<S, RequiredAr
         return this;
     }
 
+    /**
+     * Returns the {@link ArgumentType} the built command will use
+     *
+     * @return the {@link ArgumentType} the built command will use
+     */
     public ArgumentType<T> getType() {
         return type;
     }
 
+    /**
+     * Returns the name of the argument the built command will have.
+     * <p>
+     * Can be used with {@link CommandContext#getArgument} to retrieve the parsed argument
+     *
+     * @return the name of the argument the built command will have.
+     */
     public String getName() {
         return name;
     }
 
+    @Override
     public ArgumentCommandNode<S, T> build() {
         final ArgumentCommandNode<S, T> result = new ArgumentCommandNode<>(getName(), getType(), getCommand(), getRequirement(), getRedirect(), getRedirectModifier(), isFork(), getSuggestionsProvider());
 

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -4,13 +4,24 @@
 package com.mojang.brigadier.context;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
+import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.tree.CommandNode;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A general container class storing information needed to invoke a command.
+ * <p>
+ * This consists of e.g. the command source to invoke it for, the command to invoke, child contexts (for subcommands)
+ * or arguments parsed by {@link ArgumentType}s.
+ *
+ * @param <S> the type of the command source
+ */
 public class CommandContext<S> {
 
     private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER = new HashMap<>();
@@ -37,6 +48,20 @@ public class CommandContext<S> {
     private final RedirectModifier<S> modifier;
     private final boolean forks;
 
+    /**
+     * Creates a new {@link CommandContext}.
+     *
+     * @param source the command source to invoke the command for
+     * @param input the full input
+     * @param arguments the parsed arguments, as created by {@link ArgumentType}s
+     * @param command the command to invoke
+     * @param rootNode the root node of the command tree
+     * @param nodes the
+     * @param range the string range indicating what part in the input this context covers
+     * @param child the child context, or null if none
+     * @param modifier the {@link RedirectModifier} to apply when invoking the command
+     * @param forks whether this command forks. See {@link CommandDispatcher#execute(ParseResults)} for an explanation
+     */
     public CommandContext(final S source, final String input, final Map<String, ParsedArgument<S, ?>> arguments, final Command<S> command, final CommandNode<S> rootNode, final List<ParsedCommandNode<S>> nodes, final StringRange range, final CommandContext<S> child, final RedirectModifier<S> modifier, boolean forks) {
         this.source = source;
         this.input = input;
@@ -50,6 +75,12 @@ public class CommandContext<S> {
         this.forks = forks;
     }
 
+    /**
+     * Creates a copy of this {@link CommandContext} that for a different command source but otherwise identical
+     *
+     * @param source the command source to copy it for
+     * @return a {@link CommandContext} that is identical to this one, except for the command source
+     */
     public CommandContext<S> copyFor(final S source) {
         if (this.source == source) {
             return this;
@@ -57,10 +88,24 @@ public class CommandContext<S> {
         return new CommandContext<>(source, input, arguments, command, rootNode, nodes, range, child, modifier, forks);
     }
 
+    /**
+     * Returns the child context, if it is present.
+     *
+     * @return the child context, or null if there is none
+     */
     public CommandContext<S> getChild() {
         return child;
     }
 
+    /**
+     * Returns the last child command context in the chain, i.e. the lowest child you can reach from this context.
+     * <p>
+     * As each {@link CommandContext} can have child, you can have a child of a child. This method returns the lowest
+     * possible child you can reach, i.e. the last command context that has no children.
+     * This can be this command context instance, if it has no child .
+     *
+     * @return the last child command context
+     */
     public CommandContext<S> getLastChild() {
         CommandContext<S> result = this;
         while (result.getChild() != null) {
@@ -69,15 +114,33 @@ public class CommandContext<S> {
         return result;
     }
 
+    /**
+     * Returns the command that should be executed.
+     *
+     * @return the command to execute or null if not found
+     */
     public Command<S> getCommand() {
         return command;
     }
 
+    /**
+     * The command source to invoke the command for
+     *
+     * @return the command source to invoke the command for
+     */
     public S getSource() {
         return source;
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Returns an argument that was stored in this context while parsing the command.
+     *
+     * @param name the name of the argument to retrieve
+     * @param clazz the class of the argument type
+     * @param <V> the type of the argument
+     * @return the argument
+     * @throws IllegalArgumentException if the command does not exist or is of a different type
+     */
     public <V> V getArgument(final String name, final Class<V> clazz) {
         final ParsedArgument<S, ?> argument = arguments.get(name);
 
@@ -87,7 +150,9 @@ public class CommandContext<S> {
 
         final Object result = argument.getResult();
         if (PRIMITIVE_TO_WRAPPER.getOrDefault(clazz, clazz).isAssignableFrom(result.getClass())) {
-            return (V) result;
+            @SuppressWarnings("unchecked")
+            V v = (V) result;
+            return v;
         } else {
             throw new IllegalArgumentException("Argument '" + name + "' is defined as " + result.getClass().getSimpleName() + ", not " + clazz);
         }
@@ -121,30 +186,73 @@ public class CommandContext<S> {
         return result;
     }
 
+    /**
+     * Returns the {@link RedirectModifier} to apply when invoking the command.
+     *
+     * @return the  {@link RedirectModifier} to apply when invoking the command or null if none is set
+     */
     public RedirectModifier<S> getRedirectModifier() {
         return modifier;
     }
 
+    /**
+     * Returns the range this context takes up in the input string.
+     *
+     * @return the range this context takes up in the input string.
+     */
     public StringRange getRange() {
         return range;
     }
 
+    /**
+     * Returns the full input, of which this command context is a part.
+     *
+     * @return the full input, of which this command context is a part.
+     */
     public String getInput() {
         return input;
     }
 
+    /**
+     * Returns the root command node in the command tree.
+     *
+     * @return the root command node in the command tree
+     */
     public CommandNode<S> getRootNode() {
         return rootNode;
     }
 
+    /**
+     * Returns all nodes associated with this context.
+     * <p>
+     * That is the node that {@link #getCommand()} comes from any anything else that nodes pushes onto it in its
+     * {@link CommandNode#parse} method.
+     * <p>
+     * TODO: Why is this a List?
+     *
+     * @return all nodes associated with this context
+     */
     public List<ParsedCommandNode<S>> getNodes() {
         return nodes;
     }
 
+    /**
+     * Returns true if this context has any {@link CommandNode} associated with it.
+     *
+     * @return true if this context has any {@link CommandNode} associated with it
+     */
     public boolean hasNodes() {
         return !nodes.isEmpty();
     }
 
+    /**
+     * Returns true if this command is forked.
+     * <p>
+     * See {@link CommandDispatcher#execute(ParseResults)} for a detailed explanation.
+     *
+     * @return true if this command is forked
+     * @see CommandDispatcher#execute(ParseResults)
+     */
     public boolean isForked() {
         return forks;
     }

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -13,6 +13,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A builder for {@link CommandContext} objects.
+ *
+ * @param <S> the type of the command source
+ */
 public class CommandContextBuilder<S> {
     private final Map<String, ParsedArgument<S, ?>> arguments = new LinkedHashMap<>();
     private final CommandNode<S> rootNode;
@@ -25,6 +30,14 @@ public class CommandContextBuilder<S> {
     private RedirectModifier<S> modifier = null;
     private boolean forks;
 
+    /**
+     * Creates a new {@link CommandContextBuilder} with a few required arguments.
+     *
+     * @param dispatcher the {@link CommandDispatcher} TODO: Why does this exist here?
+     * @param source the command source
+     * @param rootNode the root node of the command tree
+     * @param start the start in the input that this context spans
+     */
     public CommandContextBuilder(final CommandDispatcher<S> dispatcher, final S source, final CommandNode<S> rootNode, final int start) {
         this.rootNode = rootNode;
         this.dispatcher = dispatcher;
@@ -32,33 +45,72 @@ public class CommandContextBuilder<S> {
         this.range = StringRange.at(start);
     }
 
+    /**
+     * Sets the source for this command.
+     *
+     * @param source thr command source
+     * @return this builder
+     */
     public CommandContextBuilder<S> withSource(final S source) {
         this.source = source;
         return this;
     }
 
+    /**
+     * The command source for the built command context.
+     *
+     * @return the command source for the built command context.
+     */
     public S getSource() {
         return source;
     }
 
+    /**
+     * Returns the root node in the command tree.
+     *
+     * @return the root node in the command tree
+     */
     public CommandNode<S> getRootNode() {
         return rootNode;
     }
 
+    /**
+     * Stores an argument in this command, that can later be retrieved.
+     *
+     * @param name the name of the argument
+     * @param argument the argument to store
+     * @return this builder
+     * @see CommandContext#getArgument
+     */
     public CommandContextBuilder<S> withArgument(final String name, final ParsedArgument<S, ?> argument) {
         this.arguments.put(name, argument);
         return this;
     }
 
+    /**
+     * Returns all stored arguments.
+     *
+     * @return all stored arguments
+     */
     public Map<String, ParsedArgument<S, ?>> getArguments() {
         return arguments;
     }
 
+    /**
+     * Sets the command to execute, i.e. the one that was matched by this context.
+     *
+     * @param command the {@link Command} that should be executed
+     * @return this builder
+     */
     public CommandContextBuilder<S> withCommand(final Command<S> command) {
         this.command = command;
         return this;
     }
 
+    /**
+     * TODO: What does this do? Overwrites range, modifer and forks but keeps the nodes around? Then is never called
+     * in any lib code.
+     */
     public CommandContextBuilder<S> withNode(final CommandNode<S> node, final StringRange range) {
         nodes.add(new ParsedCommandNode<>(node, range));
         this.range = StringRange.encompassing(this.range, range);
@@ -67,6 +119,13 @@ public class CommandContextBuilder<S> {
         return this;
     }
 
+    /**
+     * Creates a copy of this {@link CommandContextBuilder}.
+     * <p>
+     * Not a deep copy as Command, child, range and the arguments themselves are shared.
+     *
+     * @return a copy of this builder
+     */
     public CommandContextBuilder<S> copy() {
         final CommandContextBuilder<S> copy = new CommandContextBuilder<>(dispatcher, source, rootNode, range.getStart());
         copy.command = command;
@@ -78,15 +137,36 @@ public class CommandContextBuilder<S> {
         return copy;
     }
 
+    /**
+     * Sets a child context, which is the context for a sub command.
+     *
+     * @param child the child context
+     * @return this builder
+     */
     public CommandContextBuilder<S> withChild(final CommandContextBuilder<S> child) {
         this.child = child;
         return this;
     }
 
+    /**
+     * Returns the child context, i.e. the context for a subcommand.
+     *
+     * @return the child context, i.e. the context for a subcommand.
+     */
     public CommandContextBuilder<S> getChild() {
         return child;
     }
 
+    /**
+     * Returns the last child command context in the chain, i.e. the lowest child you can reach from this context.
+     * <p>
+     * As each {@link CommandContext} can have child, you can have a child of a child. This method returns the lowest
+     * possible child you can reach, i.e. the last command context that has no children.
+     * This can be this command context instance, if it has no child .
+     *
+     * @return the last child command context
+     * @see CommandContext#getLastChild()
+     */
     public CommandContextBuilder<S> getLastChild() {
         CommandContextBuilder<S> result = this;
         while (result.getChild() != null) {
@@ -95,26 +175,64 @@ public class CommandContextBuilder<S> {
         return result;
     }
 
+    /**
+     * Returns the command to execute.
+     *
+     * @return the command to execute.
+     */
     public Command<S> getCommand() {
         return command;
     }
 
+    /**
+     * Returns a list with all nodes.
+     *
+     * @return a list with all nodes
+     * @see CommandContext#getNodes
+     */
     public List<ParsedCommandNode<S>> getNodes() {
         return nodes;
     }
 
+    /**
+     * Builds the command context
+     *
+     * @param input the input string
+     * @return the built command context
+     */
     public CommandContext<S> build(final String input) {
         return new CommandContext<>(source, input, arguments, command, rootNode, nodes, range, child == null ? null : child.build(input), modifier, forks);
     }
 
+    /**
+     * Returns the {@link CommandDispatcher} set in the constructor.
+     * TODO: WHY?
+     *
+     * @return the {@link CommandDispatcher} set in the constructor.
+     */
     public CommandDispatcher<S> getDispatcher() {
         return dispatcher;
     }
 
+    /**
+     * Returns the range this context spans in the input.
+     *
+     * @return the range this context spans in the input.
+     */
     public StringRange getRange() {
         return range;
     }
 
+    /**
+     * Finds the {@link SuggestionContext} given a cursor value.
+     * <p>
+     * This method attempts to find the correct command node responsible at the given cursor position.
+     *
+     * @param cursor the cursor position to find a suggestion context for
+     * @return the {@link SuggestionContext} for the given cursor value
+     * @throws IllegalStateException if the cursor position is smaller than the {@link #getRange()} or not within the
+     * bounds of any registered node
+     */
     public SuggestionContext<S> findSuggestionContext(final int cursor) {
         if (range.getStart() <= cursor) {
             if (range.getEnd() < cursor) {

--- a/src/main/java/com/mojang/brigadier/context/ParsedArgument.java
+++ b/src/main/java/com/mojang/brigadier/context/ParsedArgument.java
@@ -5,19 +5,42 @@ package com.mojang.brigadier.context;
 
 import java.util.Objects;
 
+/**
+ * Represents an argument that was parsed from the input.
+ *
+ * @param <S> the type of the command source
+ * @param <T> the type of the argument
+ */
 public class ParsedArgument<S, T> {
     private final StringRange range;
     private final T result;
 
+    /**
+     * Creates a new {@link ParsedArgument} for a given string range with a  given value.
+     *
+     * @param start the start of this argument in the input
+     * @param end the end of this argument in the input
+     * @param result the value of this argument
+     */
     public ParsedArgument(final int start, final int end, final T result) {
         this.range = StringRange.between(start, end);
         this.result = result;
     }
 
+    /**
+     * Returns the range this argument spans in the input string.
+     *
+     * @return the range this argument spans in the input string
+     */
     public StringRange getRange() {
         return range;
     }
 
+    /**
+     * Returns the value of the argument.
+     *
+     * @return the value of the argument
+     */
     public T getResult() {
         return result;
     }

--- a/src/main/java/com/mojang/brigadier/context/ParsedCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/context/ParsedCommandNode.java
@@ -7,21 +7,42 @@ import com.mojang.brigadier.tree.CommandNode;
 
 import java.util.Objects;
 
+/**
+ * Represents a {@link CommandNode} that was parsed from the input.
+ *
+ * @param <S> the type of the command source
+ */
 public class ParsedCommandNode<S> {
 
     private final CommandNode<S> node;
 
     private final StringRange range;
 
+    /**
+     * Creates a new {@link ParsedCommandNode} for the given node within the given string range.
+     *
+     * @param node the node that was parsed
+     * @param range the string range in the input it was parsed from
+     */
     public ParsedCommandNode(CommandNode<S> node, StringRange range) {
         this.node = node;
         this.range = range;
     }
 
+    /**
+     * Returns the node that was parsed.
+     *
+     * @return the node that was parsed
+     */
     public CommandNode<S> getNode() {
         return node;
     }
 
+    /**
+     * Returns the range this command node spans in the input string.
+     *
+     * @return the range this command node spans in the input string
+     */
     public StringRange getRange() {
         return range;
     }

--- a/src/main/java/com/mojang/brigadier/context/StringRange.java
+++ b/src/main/java/com/mojang/brigadier/context/StringRange.java
@@ -4,50 +4,115 @@
 package com.mojang.brigadier.context;
 
 import com.mojang.brigadier.ImmutableStringReader;
+import com.mojang.brigadier.StringReader;
 
 import java.util.Objects;
 
+/**
+ * A range within a string, i.e. the start and end values of a substring.
+ */
 public class StringRange {
     private final int start;
     private final int end;
 
+    /**
+     * Creates a new {@link StringRange} with the given start and end index.
+     *
+     * @param start the start index (inclusive)
+     * @param end the end index (exclusive)
+     */
     public StringRange(final int start, final int end) {
+        // TODO: String ranges with start > end?
         this.start = start;
         this.end = end;
     }
 
+    /**
+     * Returns a {@link StringRange} spanning only a single index, the one given as an argument.
+     *
+     * @param pos the position the range should include
+     * @return a {@link StringRange} that only includes the given index
+     */
     public static StringRange at(final int pos) {
         return new StringRange(pos, pos);
     }
 
+    /**
+     * Returns a {@link StringRange} with the given start and end indices.
+     *
+     * @param start the start index (inclusive)
+     * @param end the end index (exclusive)
+     * @return s {@link StringRange} spanning the given range
+     */
     public static StringRange between(final int start, final int end) {
         return new StringRange(start, end);
     }
 
+    /**
+     * Returns a {@link StringRange} that wraps around both passed {@link StringRange}s.
+     *
+     * @param a the first {@link StringRange}
+     * @param b the second {@link StringRange}
+     * @return a {@link StringRange} that includes everything from the lowest to highest index in both ranges
+     */
     public static StringRange encompassing(final StringRange a, final StringRange b) {
         return new StringRange(Math.min(a.getStart(), b.getStart()), Math.max(a.getEnd(), b.getEnd()));
     }
 
+    /**
+     * Returns the start of this {@link StringRange} (inclusive).
+     *
+     * @return the start of this {@link StringRange} (inclusive).
+     */
     public int getStart() {
         return start;
     }
 
+    /**
+     * Returns the end of this {@link StringRange} (exclusive).
+     *
+     * @return the end of this {@link StringRange} (exclusive)
+     */
     public int getEnd() {
         return end;
     }
 
+    /**
+     * Returns the substring between the given indices from the passed {@link StringReader}.
+     *
+     * @param reader the string reader to read from
+     * @return all characters in this range in the passed reader
+     */
     public String get(final ImmutableStringReader reader) {
         return reader.getString().substring(start, end);
     }
 
+    /**
+     * Returns the substring between the given indices from the passed String.
+     * <p>
+     * Equivalent to: {@code string.substring(range.getStart(), range.getEnd()}
+     *
+     * @param string the string to read from
+     * @return all characters in this range in the passed string
+     */
     public String get(final String string) {
         return string.substring(start, end);
     }
 
+    /**
+     * Checks if this range is emtpy, i.e. contains not even a single index.
+     *
+     * @return true if this range is emtpy, i.e. contains not even a single index
+     */
     public boolean isEmpty() {
         return start == end;
     }
 
+    /**
+     * Returns the length of this string range.
+     *
+     * @return the length of this string range
+     */
     public int getLength() {
         return end - start;
     }
@@ -72,8 +137,8 @@ public class StringRange {
     @Override
     public String toString() {
         return "StringRange{" +
-            "start=" + start +
-            ", end=" + end +
-            '}';
+                "start=" + start +
+                ", end=" + end +
+                '}';
     }
 }

--- a/src/main/java/com/mojang/brigadier/context/SuggestionContext.java
+++ b/src/main/java/com/mojang/brigadier/context/SuggestionContext.java
@@ -5,10 +5,21 @@ package com.mojang.brigadier.context;
 
 import com.mojang.brigadier.tree.CommandNode;
 
+/**
+ * Represents a context for a suggestion, just encompassing a command node and where the completion start.
+ *
+ * @param <S> the type of the command source
+ */
 public class SuggestionContext<S> {
     public final CommandNode<S> parent;
     public final int startPos;
 
+    /**
+     * Creates a new {@link SuggestionContext} with the given command node and start position.
+     *
+     * @param parent the node that handles the completion
+     * @param startPos the starting position where it should complete from
+     */
     public SuggestionContext(CommandNode<S> parent, int startPos) {
         this.parent = parent;
         this.startPos = startPos;

--- a/src/main/java/com/mojang/brigadier/exceptions/BuiltInExceptionProvider.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/BuiltInExceptionProvider.java
@@ -3,6 +3,9 @@
 
 package com.mojang.brigadier.exceptions;
 
+/**
+ * Defines all build in exceptions, that are used internally by Brigadier.
+ */
 public interface BuiltInExceptionProvider {
     Dynamic2CommandExceptionType doubleTooLow();
 

--- a/src/main/java/com/mojang/brigadier/exceptions/BuiltInExceptions.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/BuiltInExceptions.java
@@ -5,6 +5,9 @@ package com.mojang.brigadier.exceptions;
 
 import com.mojang.brigadier.LiteralMessage;
 
+/**
+ * Contains all inbuilt exceptions, that are used by Brigadier.
+ */
 public class BuiltInExceptions implements BuiltInExceptionProvider {
     private static final Dynamic2CommandExceptionType DOUBLE_TOO_SMALL = new Dynamic2CommandExceptionType((found, min) -> new LiteralMessage("Double must not be less than " + min + ", found " + found));
     private static final Dynamic2CommandExceptionType DOUBLE_TOO_BIG = new Dynamic2CommandExceptionType((found, max) -> new LiteralMessage("Double must not be more than " + max + ", found " + found));

--- a/src/main/java/com/mojang/brigadier/exceptions/CommandExceptionType.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/CommandExceptionType.java
@@ -3,5 +3,8 @@
 
 package com.mojang.brigadier.exceptions;
 
+/**
+ * A marker interface that indicates that the implementing class is a valid cause for a {@link CommandSyntaxException}.
+ */
 public interface CommandExceptionType {
 }

--- a/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java
@@ -5,6 +5,11 @@ package com.mojang.brigadier.exceptions;
 
 import com.mojang.brigadier.Message;
 
+/**
+ * An exception for a syntax error that occurred while parsing or executing a command.
+ * <p>
+ * TODO: Why is this named syntax exception, when it can also occur when executing a command?
+ */
 public class CommandSyntaxException extends Exception {
     public static final int CONTEXT_AMOUNT = 10;
     public static boolean ENABLE_COMMAND_STACK_TRACES = true;
@@ -15,6 +20,12 @@ public class CommandSyntaxException extends Exception {
     private final String input;
     private final int cursor;
 
+    /**
+     * Creates a new {@link CommandSyntaxException} of a given type and with a given message.
+     *
+     * @param type the type of the exception
+     * @param message the message
+     */
     public CommandSyntaxException(final CommandExceptionType type, final Message message) {
         super(message.getString(), null, ENABLE_COMMAND_STACK_TRACES, ENABLE_COMMAND_STACK_TRACES);
         this.type = type;
@@ -23,6 +34,15 @@ public class CommandSyntaxException extends Exception {
         this.cursor = -1;
     }
 
+    /**
+     * Creates a new {@link CommandSyntaxException} of a given type and message together with the input and cursor
+     * position.
+     *
+     * @param type the type of the exception
+     * @param message the message
+     * @param input the input that caused the exception
+     * @param cursor the cursor position the exception occurred on
+     */
     public CommandSyntaxException(final CommandExceptionType type, final Message message, final String input, final int cursor) {
         super(message.getString(), null, ENABLE_COMMAND_STACK_TRACES, ENABLE_COMMAND_STACK_TRACES);
         this.type = type;
@@ -31,6 +51,11 @@ public class CommandSyntaxException extends Exception {
         this.cursor = cursor;
     }
 
+    /**
+     * Returns the message together with the position it occurred on and some context.
+     *
+     * @return the message together with the position it occurred on and some context.
+     */
     @Override
     public String getMessage() {
         String message = this.message.getString();
@@ -41,10 +66,23 @@ public class CommandSyntaxException extends Exception {
         return message;
     }
 
+    /**
+     * Returns the raw message, not including positional information
+     *
+     * @return the raw message without any formatting or positional information
+     */
     public Message getRawMessage() {
         return message;
     }
 
+    /**
+     * Returns some contextual information about where the error occurred.
+     * <p>
+     * This is done by returning a few characters of the input and a pointer to where the exception it happened.
+     *
+     * @return some contextual information about where the error occurred or null if {@link #getInput()} or
+     * {@link #getCursor()} are null/0.
+     */
     public String getContext() {
         if (input == null || cursor < 0) {
             return null;
@@ -62,14 +100,29 @@ public class CommandSyntaxException extends Exception {
         return builder.toString();
     }
 
+    /**
+     * Returns the type of the exception.
+     *
+     * @return the type of the exception
+     */
     public CommandExceptionType getType() {
         return type;
     }
 
+    /**
+     * Returns the input that caused the {@link CommandSyntaxException}.
+     *
+     * @return the input that caused the {@link CommandSyntaxException} or null if not set
+     */
     public String getInput() {
         return input;
     }
 
+    /**
+     * Returns the cursor position.
+     *
+     * @return the cursor position or -1 if not set
+     */
     public int getCursor() {
         return cursor;
     }

--- a/src/main/java/com/mojang/brigadier/exceptions/Dynamic2CommandExceptionType.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/Dynamic2CommandExceptionType.java
@@ -6,6 +6,12 @@ package com.mojang.brigadier.exceptions;
 import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.Message;
 
+/**
+ * A {@link CommandExceptionType} taking two inputs and returning a message based on those.
+ * <p>
+ * The arguments can be used to e.g. format a message and display the input as well as why it did not match some
+ * criteria.
+ */
 public class Dynamic2CommandExceptionType implements CommandExceptionType {
     private final Function function;
 
@@ -13,14 +19,34 @@ public class Dynamic2CommandExceptionType implements CommandExceptionType {
         this.function = function;
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the two passed arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException create(final Object a, final Object b) {
         return new CommandSyntaxException(this, function.apply(a, b));
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the two passed arguments and includes information about the
+     * position and input.
+     *
+     * @param reader the {@link ImmutableStringReader} giving information about the input and the place the error
+     * occurred
+     * @param a the first argument
+     * @param b the second argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException createWithContext(final ImmutableStringReader reader, final Object a, final Object b) {
         return new CommandSyntaxException(this, function.apply(a, b), reader.getString(), reader.getCursor());
     }
 
+    /**
+     * A simple Function to compute a {@link Message} based on the two input arguments.
+     */
     public interface Function {
         Message apply(Object a, Object b);
     }

--- a/src/main/java/com/mojang/brigadier/exceptions/Dynamic3CommandExceptionType.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/Dynamic3CommandExceptionType.java
@@ -6,6 +6,12 @@ package com.mojang.brigadier.exceptions;
 import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.Message;
 
+/**
+ * A {@link CommandExceptionType} taking three inputs and returning a message based on those.
+ * <p>
+ * The arguments can be used to e.g. format a message and display the input as well as why it did not match some
+ * criteria.
+ */
 public class Dynamic3CommandExceptionType implements CommandExceptionType {
     private final Function function;
 
@@ -13,14 +19,36 @@ public class Dynamic3CommandExceptionType implements CommandExceptionType {
         this.function = function;
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the three passed arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException create(final Object a, final Object b, final Object c) {
         return new CommandSyntaxException(this, function.apply(a, b, c));
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the three passed arguments and includes information about the
+     * position and input.
+     *
+     * @param reader the {@link ImmutableStringReader} giving information about the input and the place the error
+     * occurred
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException createWithContext(final ImmutableStringReader reader, final Object a, final Object b, final Object c) {
         return new CommandSyntaxException(this, function.apply(a, b, c), reader.getString(), reader.getCursor());
     }
 
+    /**
+     * A simple Function to compute a {@link Message} based on the three input arguments.
+     */
     public interface Function {
         Message apply(Object a, Object b, Object c);
     }

--- a/src/main/java/com/mojang/brigadier/exceptions/Dynamic4CommandExceptionType.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/Dynamic4CommandExceptionType.java
@@ -6,6 +6,12 @@ package com.mojang.brigadier.exceptions;
 import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.Message;
 
+/**
+ * A {@link CommandExceptionType} taking four inputs and returning a message based on those.
+ * <p>
+ * The arguments can be used to e.g. format a message and display the input as well as why it did not match some
+ * criteria.
+ */
 public class Dynamic4CommandExceptionType implements CommandExceptionType {
     private final Function function;
 
@@ -13,14 +19,38 @@ public class Dynamic4CommandExceptionType implements CommandExceptionType {
         this.function = function;
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the four passed arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException create(final Object a, final Object b, final Object c, final Object d) {
         return new CommandSyntaxException(this, function.apply(a, b, c, d));
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the four passed arguments and includes information about the
+     * position and input.
+     *
+     * @param reader the {@link ImmutableStringReader} giving information about the input and the place the error
+     * occurred
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException createWithContext(final ImmutableStringReader reader, final Object a, final Object b, final Object c, final Object d) {
         return new CommandSyntaxException(this, function.apply(a, b, c, d), reader.getString(), reader.getCursor());
     }
 
+    /**
+     * A simple Function to compute a {@link Message} based on the four input arguments.
+     */
     public interface Function {
         Message apply(Object a, Object b, Object c, Object d);
     }

--- a/src/main/java/com/mojang/brigadier/exceptions/DynamicCommandExceptionType.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/DynamicCommandExceptionType.java
@@ -8,6 +8,12 @@ import com.mojang.brigadier.Message;
 
 import java.util.function.Function;
 
+/**
+ * A {@link CommandExceptionType} taking one input and returning a message based on it.
+ * <p>
+ * The argument can be used to e.g. format a message and display the input as well as why it did not match some
+ * criteria.
+ */
 public class DynamicCommandExceptionType implements CommandExceptionType {
     private final Function<Object, Message> function;
 
@@ -15,10 +21,25 @@ public class DynamicCommandExceptionType implements CommandExceptionType {
         this.function = function;
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the passed argument.
+     *
+     * @param arg the argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException create(final Object arg) {
         return new CommandSyntaxException(this, function.apply(arg));
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the passed argument and includes information about the
+     * position and input.
+     *
+     * @param reader the {@link ImmutableStringReader} giving information about the input and the place the error
+     * occurred
+     * @param arg the argument
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException createWithContext(final ImmutableStringReader reader, final Object arg) {
         return new CommandSyntaxException(this, function.apply(arg), reader.getString(), reader.getCursor());
     }

--- a/src/main/java/com/mojang/brigadier/exceptions/DynamicNCommandExceptionType.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/DynamicNCommandExceptionType.java
@@ -6,6 +6,12 @@ package com.mojang.brigadier.exceptions;
 import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.Message;
 
+/**
+ * A {@link CommandExceptionType} taking an arbitrary number of inputs and returning a message based on those.
+ * <p>
+ * The arguments can be used to e.g. format a message and display the input as well as why it did not match some
+ * criteria.
+ */
 public class DynamicNCommandExceptionType implements CommandExceptionType {
     private final Function function;
 
@@ -13,14 +19,33 @@ public class DynamicNCommandExceptionType implements CommandExceptionType {
         this.function = function;
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the passed arguments.
+     *
+     * @param a the first argument
+     * @param args the other arguments
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException create(final Object a, final Object... args) {
         return new CommandSyntaxException(this, function.apply(args));
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} using the passed arguments and includes information about the
+     * position and input.
+     *
+     * @param reader the {@link ImmutableStringReader} giving information about the input and the place the error
+     * occurred
+     * @param args the arguments
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException createWithContext(final ImmutableStringReader reader, final Object... args) {
         return new CommandSyntaxException(this, function.apply(args), reader.getString(), reader.getCursor());
     }
 
+    /**
+     * A simple Function to compute a {@link Message} based on the input arguments.
+     */
     public interface Function {
         Message apply(Object[] args);
     }

--- a/src/main/java/com/mojang/brigadier/exceptions/SimpleCommandExceptionType.java
+++ b/src/main/java/com/mojang/brigadier/exceptions/SimpleCommandExceptionType.java
@@ -6,6 +6,11 @@ package com.mojang.brigadier.exceptions;
 import com.mojang.brigadier.ImmutableStringReader;
 import com.mojang.brigadier.Message;
 
+/**
+ * A simple {@link CommandExceptionType} that gives a static message, that does not change based on the type of error.
+ * <p>
+ * An example could be a message displaying a command was not found, but not including the full inout again.
+ */
 public class SimpleCommandExceptionType implements CommandExceptionType {
     private final Message message;
 
@@ -13,10 +18,22 @@ public class SimpleCommandExceptionType implements CommandExceptionType {
         this.message = message;
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException}.
+     *
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException create() {
         return new CommandSyntaxException(this, message);
     }
 
+    /**
+     * Creates a {@link CommandSyntaxException} including information about the position and input.
+     *
+     * @param reader the {@link ImmutableStringReader} giving information about the input and the place the error
+     * occurred
+     * @return a constructed {@link CommandSyntaxException}
+     */
     public CommandSyntaxException createWithContext(final ImmutableStringReader reader) {
         return new CommandSyntaxException(this, message, reader.getString(), reader.getCursor());
     }

--- a/src/main/java/com/mojang/brigadier/suggestion/IntegerSuggestion.java
+++ b/src/main/java/com/mojang/brigadier/suggestion/IntegerSuggestion.java
@@ -8,18 +8,39 @@ import com.mojang.brigadier.context.StringRange;
 
 import java.util.Objects;
 
+/**
+ * A {@link Suggestion} that suggests integers and orders them correctly.
+ */
 public class IntegerSuggestion extends Suggestion {
     private int value;
 
+    /**
+     * Creates a new {@link IntegerSuggestion} that covers a given range and has a given int value.
+     *
+     * @param range the range it covers in the input
+     * @param value the integer value
+     */
     public IntegerSuggestion(final StringRange range, final int value) {
         this(range, value, null);
     }
 
+    /**
+     * Creates a new {@link IntegerSuggestion} that covers a given range and has a given int value and tooltip.
+     *
+     * @param range the range it covers in the input
+     * @param value the integer value
+     * @param tooltip a tooltip message to show the user
+     */
     public IntegerSuggestion(final StringRange range, final int value, final Message tooltip) {
         super(range, Integer.toString(value), tooltip);
         this.value = value;
     }
 
+    /**
+     * Returns the underlying integer value.
+     *
+     * @return the underlying integer value.
+     */
     public int getValue() {
         return value;
     }

--- a/src/main/java/com/mojang/brigadier/suggestion/Suggestion.java
+++ b/src/main/java/com/mojang/brigadier/suggestion/Suggestion.java
@@ -8,33 +8,95 @@ import com.mojang.brigadier.context.StringRange;
 
 import java.util.Objects;
 
+/**
+ * A suggestion that the user could incorporate into his command, which can be used for displaying information about
+ * possible next values.
+ * <p>
+ * An example would be tab completion showing you the suggestions on the fly.
+ */
 public class Suggestion implements Comparable<Suggestion> {
     private final StringRange range;
     private final String text;
     private final Message tooltip;
 
+    /**
+     * Creates a new {@link Suggestion} spanning the given string range in the input and that has a given text it
+     * suggests.
+     *
+     * @param range the range in the input it is applicable in
+     * @param text the replacement it suggests
+     */
     public Suggestion(final StringRange range, final String text) {
         this(range, text, null);
     }
 
+    /**
+     * Creates a new {@link Suggestion} spanning the given string range in the input, a given text it suggests and
+     * that provides a tooltip.
+     *
+     * @param range the range in the input it is applicable in
+     * @param text the replacement it suggests
+     * @param tooltip some explanatory tooltip to show to the user, before they apply the suggestion
+     */
     public Suggestion(final StringRange range, final String text, final Message tooltip) {
         this.range = range;
         this.text = text;
         this.tooltip = tooltip;
     }
 
+    /**
+     * Returns the range in the input string this suggestion is applicable in.
+     *
+     * @return the range in the input it is applicable in
+     */
     public StringRange getRange() {
         return range;
     }
 
+    /**
+     * Returns the text this suggestion suggests.
+     *
+     * @return the text this suggestion suggests.
+     */
     public String getText() {
         return text;
     }
 
+    /**
+     * Returns the tooltip with some explanatory message for the user.
+     *
+     * @return the tooltip with some explanatory message for the user or null if not set
+     */
     public Message getTooltip() {
         return tooltip;
     }
 
+    // @formatter:off
+    /**
+     * Applies the suggestion to the input.
+     *
+     * This method will replace or insert the {@link #getText()} into the passed input string.
+     *
+     * <br>An Example with the text {@code fizz}:
+     * <ul>
+     *     <li>
+     *         Input: {@code buzz}, range 0-4
+     *         <br>Output: {@code fizz}
+     *     </li>
+     *     <li>
+     *         Input: {@code buzz}, range 0-0
+     *         <br>Output: {@code fizzbuzz}
+     *     </li>
+     *     <li>
+     *         Input: {@code buzz}, range 4-4
+     *         <br>Output: {@code buzzfizz}
+     *     </li>
+     * </ul>
+     * @param input the input string to apply it to
+     * @return the result of applying the suggestion to the input
+     * @throws StringIndexOutOfBoundsException if the range is not contained into the input string
+     */
+    // @formatter:on
     public String apply(final String input) {
         if (range.getStart() == 0 && range.getEnd() == input.length()) {
             return text;
@@ -70,10 +132,10 @@ public class Suggestion implements Comparable<Suggestion> {
     @Override
     public String toString() {
         return "Suggestion{" +
-            "range=" + range +
-            ", text='" + text + '\'' +
-            ", tooltip='" + tooltip + '\'' +
-            '}';
+                "range=" + range +
+                ", text='" + text + '\'' +
+                ", tooltip='" + tooltip + '\'' +
+                '}';
     }
 
     @Override
@@ -81,10 +143,47 @@ public class Suggestion implements Comparable<Suggestion> {
         return text.compareTo(o.text);
     }
 
+    /**
+     * Compares the {@link #getText()}  of this suggestion ot the {@link #getText()} of the other, ignoring case.
+     *
+     * @param b the suggestion to compare it to
+     * @return -1 if this suggestion is less than the other, 0 if they are equal or 1 if this suggestion is bigger
+     * than the other
+     * @see String#compareToIgnoreCase
+     */
     public int compareToIgnoreCase(final Suggestion b) {
         return text.compareToIgnoreCase(b.text);
     }
 
+    // @formatter:off
+    /**
+     * Expands this suggestion by changing the range to the passed one and filling everything that lies outside
+     * {@link #getText()} with characters from the passed command.
+     *
+     * <br>Examples with text = {@code ----} and range = {@code 0} and the text to apply it to as {@code abcdefghi}:
+     * <ul>
+     *     <li>
+     *         {@code expand("123", StringRange.at(0)}:
+     *         <br>{@code ----abcdefghi}, as the ranges matched and so nothing was changed
+     *     </li>
+     *     <li>
+     *         {@code expand("123", StringRange.at(1)}:
+     *         <br>{@code a----1bcdefghi}, as the passed range (1) was taken and one character from the command was
+     *         used to fill up the index 1, as the range of the original suggestion was 0
+     *     </li>
+     *     <li>
+     *         {@code expand("123", StringRange.between(1, 3)}:
+     *         <br>{@code a----123defghi}, as the passed range (1,3) was taken and 3 character from the command were
+     *         used to fill up the indices 1,2 and 3, as the range of the original suggestion was 0. it is then inserted
+     *         after the first character in the text it is applied to (after the a) and replaces everything that lies in
+     *         its interval (bc).
+     *     </li>
+     * </ul>
+     * @param command the command to fill the range up with
+     * @param range the range to widen it to
+     * @return the expanded suggestion
+     */
+    // @formatter:on
     public Suggestion expand(final String command, final StringRange range) {
         if (range.equals(this.range)) {
             return this;

--- a/src/main/java/com/mojang/brigadier/suggestion/SuggestionProvider.java
+++ b/src/main/java/com/mojang/brigadier/suggestion/SuggestionProvider.java
@@ -8,7 +8,25 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A provider that generates suggestions based on a context and adds them to a builder it then returns.
+ * <p>
+ * As looking up the suggestions might involve about anything, from querying game state to I/O, the method returns a
+ * {@link CompletableFuture} and no guarantees are made about its execution.
+ *
+ * @param <S> the type of the command source
+ */
 @FunctionalInterface
 public interface SuggestionProvider<S> {
+    /**
+     * Computes suggestions for the given {@link CommandContext} and adds them to a {@link SuggestionsBuilder} it then
+     * builds.
+     *
+     * @param context the command context to as a base
+     * @param builder the builder to add them to
+     * @return a completable future that might complete, as computing the suggestions might involve arbitrary
+     * computations and even I/O
+     * @throws CommandSyntaxException if an error occurs parsing the context to return a valid suggestion
+     */
     CompletableFuture<Suggestions> getSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/suggestion/Suggestions.java
+++ b/src/main/java/com/mojang/brigadier/suggestion/Suggestions.java
@@ -13,6 +13,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A collection of {@link Suggestion}s.
+ */
 public class Suggestions {
     private static final Suggestions EMPTY = new Suggestions(StringRange.at(0), new ArrayList<>());
 
@@ -24,14 +27,29 @@ public class Suggestions {
         this.suggestions = suggestions;
     }
 
+    /**
+     * Returns the range the suggestions span.
+     *
+     * @return the range the suggestions span.
+     */
     public StringRange getRange() {
         return range;
     }
 
+    /**
+     * Returns all suggestions as a list.
+     *
+     * @return all suggestions as a list
+     */
     public List<Suggestion> getList() {
         return suggestions;
     }
 
+    /**
+     * Checks if no suggestions are stored in this object..
+     *
+     * @return true if no suggestions are stored in this object
+     */
     public boolean isEmpty() {
         return suggestions.isEmpty();
     }
@@ -46,7 +64,7 @@ public class Suggestions {
         }
         final Suggestions that = (Suggestions) o;
         return Objects.equals(range, that.range) &&
-            Objects.equals(suggestions, that.suggestions);
+                Objects.equals(suggestions, that.suggestions);
     }
 
     @Override
@@ -57,15 +75,29 @@ public class Suggestions {
     @Override
     public String toString() {
         return "Suggestions{" +
-            "range=" + range +
-            ", suggestions=" + suggestions +
-            '}';
+                "range=" + range +
+                ", suggestions=" + suggestions +
+                '}';
     }
 
+    /**
+     * Returns a future that instantly completes with an empty {@link Suggestions} instance.
+     *
+     * @return a future that instantly completes with an empty {@link Suggestions} instance
+     */
     public static CompletableFuture<Suggestions> empty() {
         return CompletableFuture.completedFuture(EMPTY);
     }
 
+    /**
+     * Merges multiple {@link Suggestions} instances for a single command.
+     * <p>
+     * Just combines the input into one collection and then calls {@link #create} with the result.
+     *
+     * @param command the command
+     * @param input the suggestions instances
+     * @return returns a merged {@link Suggestions} instance
+     */
     public static Suggestions merge(final String command, final Collection<Suggestions> input) {
         if (input.isEmpty()) {
             return EMPTY;
@@ -80,6 +112,38 @@ public class Suggestions {
         return create(command, texts);
     }
 
+    /**
+     * Creates a {@link Suggestions} instance from a command a list of possible {@link Suggestion}s.
+     * <p>
+     * The {@link Suggestions} instance will span the entire range, from the minimal index to maximum index found
+     * in the suggestions.
+     * <p>
+     * It will also automatically call {@link Suggestion#expand} for every possible suggestion, using the command and
+     * the computed general range.
+     * <p>
+     * After all of that it sorts the results and returns them.
+     * <p>
+     * <br>Some examples:
+     * <pre>
+     *     Suggestion foo = new Suggestion(StringRange.between(0, 2), "foo");
+     *     Suggestion bar = new Suggestion(StringRange.at(2), "bar");
+     *
+     *     Suggestions suggestions = Suggestions.create("1234567", List.of(foo, bar));
+     *     for (Suggestion suggestion : suggestions.getList()) {
+     *         System.out.println(suggestion.apply("abcdefgh"));
+     *     }
+     * </pre>
+     * Prints:
+     * <pre>
+     *     (ordered alphabetically)
+     *     12barcdefgh (range expanded from 0 to 2, so it replaced "ab"
+     *     foocdefgh (range was already 0 to 2, so nothing really changed
+     * </pre>
+     *
+     * @param command the command to get them for
+     * @param suggestions a list with possible suggestions
+     * @return a {@link Suggestions} instance for the given command with the passed suggestions
+     */
     public static Suggestions create(final String command, final Collection<Suggestion> suggestions) {
         if (suggestions.isEmpty()) {
             return EMPTY;

--- a/src/main/java/com/mojang/brigadier/suggestion/SuggestionsBuilder.java
+++ b/src/main/java/com/mojang/brigadier/suggestion/SuggestionsBuilder.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A builder to simplify creating {@link Suggestions} instances.
+ */
 public class SuggestionsBuilder {
     private final String input;
     private final int start;
@@ -22,26 +25,57 @@ public class SuggestionsBuilder {
         this.remaining = input.substring(start);
     }
 
+    /**
+     * Returns the full input this builder was created with.
+     *
+     * @return the input
+     */
     public String getInput() {
         return input;
     }
 
+    /**
+     * Returns the start index of the suggestions in the input.
+     *
+     * @return the start index of the suggestions in the input
+     */
     public int getStart() {
         return start;
     }
 
+    /**
+     * Returns the text that remains untouched by the suggestions
+     *
+     * @return the text that remains untouched by the suggestions
+     */
     public String getRemaining() {
         return remaining;
     }
 
+    /**
+     * Builds a {@link Suggestions} instance based on this builder.
+     *
+     * @return a {@link Suggestions} instance based on this builder
+     */
     public Suggestions build() {
         return Suggestions.create(input, result);
     }
 
+    /**
+     * Builds the suggestions and returns the result in a future that instantly completes.
+     *
+     * @return the result as a future
+     */
     public CompletableFuture<Suggestions> buildFuture() {
         return CompletableFuture.completedFuture(build());
     }
 
+    /**
+     * Suggests some replacement text for the entire range from {@link #getStart()} to the end.
+     *
+     * @param text the text to suggest
+     * @return this builder
+     */
     public SuggestionsBuilder suggest(final String text) {
         if (text.equals(remaining)) {
             return this;
@@ -50,6 +84,14 @@ public class SuggestionsBuilder {
         return this;
     }
 
+    /**
+     * Suggests some replacement text for the entire range from {@link #getStart()} to the end and provides a user
+     * readable tooltip.
+     *
+     * @param text the text to suggest
+     * @param tooltip the tooltip to add to the suggestion
+     * @return this builder
+     */
     public SuggestionsBuilder suggest(final String text, final Message tooltip) {
         if (text.equals(remaining)) {
             return this;
@@ -58,25 +100,59 @@ public class SuggestionsBuilder {
         return this;
     }
 
+    /**
+     * Suggests some replacement integer for the entire range from {@link #getStart()} to the end.
+     *
+     * @param value the value to suggest
+     * @return this builder
+     */
     public SuggestionsBuilder suggest(final int value) {
         result.add(new IntegerSuggestion(StringRange.between(start, input.length()), value));
         return this;
     }
 
+    /**
+     * Suggests some replacement integer for the entire range from {@link #getStart()} to the end and provides a user
+     * readable tooltip.
+     *
+     * @param value the integer to suggest
+     * @param tooltip the tooltip to add to the suggestion
+     * @return this builder
+     */
     public SuggestionsBuilder suggest(final int value, final Message tooltip) {
         result.add(new IntegerSuggestion(StringRange.between(start, input.length()), value, tooltip));
         return this;
     }
 
+    /**
+     * Adds all suggestions from another {@link SuggestionsBuilder}.
+     *
+     * @param other the other builder
+     * @return this builder
+     */
     public SuggestionsBuilder add(final SuggestionsBuilder other) {
         result.addAll(other.result);
         return this;
     }
 
+    /**
+     * Create a new {@link SuggestionsBuilder} for the same input but a new start index.
+     *
+     * @param start the new start index
+     * @return the new builder with the same input, no suggestions and starting at {@code start}
+     */
     public SuggestionsBuilder createOffset(final int start) {
         return new SuggestionsBuilder(input, start);
     }
 
+    /**
+     * Creates a builder with the same input and start index but no suggestions.
+     * <p>
+     * It effectively creates a copy with nothing set, hence the term "restart".
+     *
+     * @return the new builder with the same input and start index, but no completions
+     * @see #createOffset
+     */
     public SuggestionsBuilder restart() {
         return new SuggestionsBuilder(input, start);
     }

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
@@ -20,6 +21,19 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
+/**
+ * A {@link CommandNode} that is triggered by an argument, like a number.
+ * <p>
+ * The type of the argument is set via an {@link ArgumentType}, which takes care of parsing the stringified argument
+ * passed by users.
+ * <p>
+ * <br>A short <strong>example</strong>:
+ * <br>A subcommand for a delete command, taking the number of messages to delete. The {@link ArgumentType} would be an
+ * {@link IntegerArgumentType} then and the built command would parse things like {@literal "20"} or {@literal "-230"}.
+ *
+ * @param <S> the type of the command source
+ * @param <T> the {@link ArgumentType} the built command will use
+ */
 public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     private static final String USAGE_ARGUMENT_OPEN = "<";
     private static final String USAGE_ARGUMENT_CLOSE = ">";
@@ -35,6 +49,11 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
         this.customSuggestions = customSuggestions;
     }
 
+    /**
+     * Returns the {@link ArgumentType} of this command
+     *
+     * @return the {@link ArgumentType} of this command
+     */
     public ArgumentType<T> getType() {
         return type;
     }
@@ -49,6 +68,11 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
         return USAGE_ARGUMENT_OPEN + name + USAGE_ARGUMENT_CLOSE;
     }
 
+    /**
+     * Returns the {@link SuggestionProvider} the command uses to advice the user on possible completions.
+     *
+     * @return the registered {@link SuggestionProvider} or null if none
+     */
     public SuggestionProvider<S> getCustomSuggestions() {
         return customSuggestions;
     }
@@ -126,6 +150,6 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
 
     @Override
     public String toString() {
-        return "<argument " + name + ":" + type +">";
+        return "<argument " + name + ":" + type + ">";
     }
 }

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -5,6 +5,8 @@ package com.mojang.brigadier.tree;
 
 import com.mojang.brigadier.AmbiguityConsumer;
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.builder.ArgumentBuilder;
@@ -24,6 +26,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * The abstract base for the command tree, just representing a single command node.
+ *
+ * @param <S> the type of the command source
+ */
 public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
     private Map<String, CommandNode<S>> children = new LinkedHashMap<>();
     private Map<String, LiteralCommandNode<S>> literals = new LinkedHashMap<>();
@@ -42,30 +49,72 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         this.forks = forks;
     }
 
+    /**
+     * Returns the command to execute when executing this command.
+     *
+     * @return the command to execute when executing this command
+     */
     public Command<S> getCommand() {
         return command;
     }
 
+    /**
+     * Returns all child commands.
+     *
+     * @return all child commands
+     */
     public Collection<CommandNode<S>> getChildren() {
         return children.values();
     }
 
+    /**
+     * Returns a child with the given {@link #getName}.
+     *
+     * @param name the name of the child command
+     * @return the child with that name or null if not found
+     */
     public CommandNode<S> getChild(final String name) {
         return children.get(name);
     }
 
+    /**
+     * Returns the command node to redirect to.
+     *
+     * @return the command node to redirect to or null if none
+     */
     public CommandNode<S> getRedirect() {
         return redirect;
     }
 
+    /**
+     * Returns the redirect modifier to apply when redirecting.
+     *
+     * @return the redirect modifier to apply when redirecting or null if none
+     */
     public RedirectModifier<S> getRedirectModifier() {
         return modifier;
     }
 
+    /**
+     * Checks whether the given command source can use this command.
+     * <p>
+     * This just checks the {@link #getRequirement()} predicate, which could e.g. check for permissions.
+     *
+     * @param source the command source to check for
+     * @return true if the given command source can use this command.
+     */
     public boolean canUse(final S source) {
         return requirement.test(source);
     }
 
+    /**
+     * Adds a new child node to this command node.
+     * <p>
+     * This will replace commands with the same name.
+     *
+     * @param node the child command node to add
+     * @throws UnsupportedOperationException if you try to add a {@link RootCommandNode} to any other command
+     */
     public void addChild(final CommandNode<S> node) {
         if (node instanceof RootCommandNode) {
             throw new UnsupportedOperationException("Cannot add a RootCommandNode as a child to any other CommandNode");
@@ -92,6 +141,14 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         children = children.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
 
+    /**
+     * Tries to find ambiguities in the children of this command and recurses down.
+     * <p>
+     * This can be used to detect whether multiple paths could be taken with a single input, which is not an ideal state
+     * for parsing commands. See {@link CommandDispatcher#findAmbiguities} for more information.
+     *
+     * @param consumer the {@link AmbiguityConsumer} to call when ambiguities are found
+     */
     public void findAmbiguities(final AmbiguityConsumer<S> consumer) {
         Set<String> matches = new HashSet<>();
 
@@ -117,6 +174,15 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         }
     }
 
+    /**
+     * Checks if the given input is valid for this command, i.e. if it is what the command expects.
+     * <p>
+     * This is used to find ambiguities.
+     *
+     * @param input the input to check
+     * @return true if the given input is valid.
+     * @see #findAmbiguities}
+     */
     protected abstract boolean isValidInput(final String input);
 
     @Override
@@ -137,22 +203,70 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         return 31 * children.hashCode() + (command != null ? command.hashCode() : 0);
     }
 
+    /**
+     * Returns the requirement for this command, that is used by {@link #canUse(Object)}.
+     *
+     * @return the requirement for this command, that is used by {@link #canUse(Object)}.
+     */
     public Predicate<S> getRequirement() {
         return requirement;
     }
 
+    /**
+     * Returns the name of this command.
+     *
+     * @return the name of this command
+     */
     public abstract String getName();
 
+    /**
+     * Returns some usage text for this command.
+     *
+     * @return some usage text for this command
+     */
     public abstract String getUsageText();
 
+    /**
+     * Tries to parse the command given by the reader and stores the results in the contextBuilder.
+     *
+     * @param reader the reader to read from
+     * @param contextBuilder the context builder to store the results in
+     * @throws CommandSyntaxException if the input was malformed
+     */
     public abstract void parse(StringReader reader, CommandContextBuilder<S> contextBuilder) throws CommandSyntaxException;
 
+    /**
+     * Lists suggestions for this command, given the context and uses the passed {@link SuggestionsBuilder} to build
+     * them.
+     *
+     * @param context the {@link CommandContext} to use for finding suggestions
+     * @param builder the suggestions builder
+     * @return a completable future that might complete sometime in the future, as finding suggestions could involve
+     * I/O or other slow things
+     * @throws CommandSyntaxException if the command is not well formed
+     */
     public abstract CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) throws CommandSyntaxException;
 
+    /**
+     * Creates a builder for this command.
+     *
+     * @return a builder for this command
+     */
     public abstract ArgumentBuilder<S, ?> createBuilder();
 
+    /**
+     * Returns a key for this command, that is used for sorting the commands
+     *
+     * @return a key for this command, that is used for sorting the output
+     */
     protected abstract String getSortedKey();
 
+    /**
+     * Returns all relevant nodes for the input, so all nodes that are probably able to parse the input.
+     *
+     * @param input the input to check for
+     * @return all relevant nodes for the input, so all nodes that are probably able to parse the input
+     */
     public Collection<? extends CommandNode<S>> getRelevantNodes(final StringReader input) {
         if (literals.size() > 0) {
             final int cursor = input.getCursor();
@@ -181,9 +295,22 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         return (o instanceof LiteralCommandNode) ? 1 : -1;
     }
 
+    /**
+     * Checks whether this command forks.
+     * <p>
+     * See {@link CommandDispatcher#execute(ParseResults)} for an explanation of what it does
+     *
+     * @return true if this command forks.
+     */
     public boolean isFork() {
         return forks;
     }
 
+    /**
+     * Returns example usages for this command, which are used to find ambiguities.
+     *
+     * @return some example usages for this command, which are used to find ambiguities.
+     * @see #findAmbiguities
+     */
     public abstract Collection<String> getExamples();
 }

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -19,6 +19,13 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
+/**
+ * An {@link CommandNode} that is triggered by a literal (i.e. fixed) keyword.
+ * <p>
+ * An example would be a command like "ping", that is identified by its keyword.
+ *
+ * @param <S> the type of the command source
+ */
 public class LiteralCommandNode<S> extends CommandNode<S> {
     private final String literal;
 
@@ -27,6 +34,11 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
         this.literal = literal;
     }
 
+    /**
+     * Returns the literal this command is triggered by.
+     *
+     * @return the literal this command is triggered by
+     */
     public String getLiteral() {
         return literal;
     }

--- a/src/main/java/com/mojang/brigadier/tree/RootCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/RootCommandNode.java
@@ -15,30 +15,64 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * The root of the command node tree, which has basically no functionality except to hold the tree together.
+ *
+ * @param <S> the type of the command source
+ */
 public class RootCommandNode<S> extends CommandNode<S> {
     public RootCommandNode() {
         super(null, c -> true, null, s -> Collections.singleton(s.getSource()), false);
     }
 
+    /**
+     * Returns an empty string
+     *
+     * @return an empty string
+     */
     @Override
     public String getName() {
         return "";
     }
 
+    /**
+     * Returns an empty string
+     *
+     * @return an empty string
+     */
     @Override
     public String getUsageText() {
         return "";
     }
 
+    /**
+     * Is a NOP.
+     *
+     * @param reader {@inheritDoc}
+     * @param contextBuilder {@inheritDoc}
+     */
     @Override
     public void parse(final StringReader reader, final CommandContextBuilder<S> contextBuilder) throws CommandSyntaxException {
     }
 
+    /**
+     * Returns an empty {@link Suggestions} object.
+     *
+     * @param context {@inheritDoc}
+     * @param builder {@inheritDoc}
+     * @return an empty {@link Suggestions} object.
+     */
     @Override
     public CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
         return Suggestions.empty();
     }
 
+    /**
+     * Always returns false.
+     *
+     * @param input {@inheritDoc}
+     * @return {@inheritDoc}
+     */
     @Override
     public boolean isValidInput(final String input) {
         return false;
@@ -51,16 +85,32 @@ public class RootCommandNode<S> extends CommandNode<S> {
         return super.equals(o);
     }
 
+    /**
+     * Always throws an {@link IllegalStateException}.
+     *
+     * @return nothing
+     * @throws IllegalStateException if you invoke it
+     */
     @Override
     public ArgumentBuilder<S, ?> createBuilder() {
         throw new IllegalStateException("Cannot convert root into a builder");
     }
 
+    /**
+     * Returns an empty string
+     *
+     * @return an empty string
+     */
     @Override
     protected String getSortedKey() {
         return "";
     }
 
+    /**
+     * Returns an empty list
+     *
+     * @return an empty list
+     */
     @Override
     public Collection<String> getExamples() {
         return Collections.emptyList();


### PR DESCRIPTION
Sorry for the large PR, but I wasn't sure if and where to split it up.

## Content
This PR should only contain javadoc, but that for about any public member I could find.
The goal is to hopefully make navigating the API outside of CommandDispatcher a little less annoying and clarify the usage. What is still missing are some proper walkthroughs or tutorials that actually walk you through achieving some goal, but IMHO useful javadoc is a good first step.

I *hope* the doc I wrote is useful but contributions, questions and clarifications are more than welcome!

## Problems
The docs still have around 6 places marked with `TODO: XXX`, indicating that I had no idea why a certain choice was made and therefore could not write docs for it. The other place is in the Suggestions create/merge methods, as I know how they work but not what they are used for. Here is a list with all TODOs:
- [ ] `Command#run` throws a Command**Syntax**Exception, but is *executed* and not parsed here
- [ ] `CommandContextBuilder` contains a `CommandDispatcher` which is never used and not present in the `CommandContext`
- [ ] Why does the `CommandContext(Builder)` contain a *list* of nodes, when the `withNode` method replaces all relevant fields but only keeps the old node around? And the only use case for `getNodes` I have found is to get the node for the attached command, so the last one. The only references in the project also just fetch *one* node.
- [ ] `StringRange` constructor: Why allow ranges where the start is greater than the end? Something like `start = 20, end = 5` might not be ideal.
- [ ] `CommandSyntaxException` seems to be more than just a *syntax* exception. Why is only syntax in the name then?

- [ ] Some clarification about how `Suggestions#merge` and `Suggestions#create` work/are used for

## Other
Clarifications and change requests/comments are welcome!