### PR TITLE
Add recursive command that does not cause stack overflow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'com.google.guava:guava-testlib:26.0-jre'
     testCompile 'org.openjdk.jmh:jmh-core:1.21'
-    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
+    //annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
 }
 
 task sourcesJar(type: Jar) {

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -144,6 +144,10 @@ public class CommandDispatcher<S> {
         return execute(new StringReader(input), source);
     }
 
+    public DispatchingState<S> executeCumulative(final String input, final S source) throws CommandSyntaxException {
+        return executeCumulative(new StringReader(input), source);
+    }
+
     /**
      * Parses and executes a given command.
      *
@@ -179,6 +183,11 @@ public class CommandDispatcher<S> {
         return execute(parse);
     }
 
+    public DispatchingState<S> executeCumulative(final StringReader input, final S source) throws CommandSyntaxException {
+        final ParseResults<S> parse = parse(input, source);
+        return executeCumulative(parse);
+    }
+
     /**
      * Executes a given pre-parsed command.
      *
@@ -209,6 +218,10 @@ public class CommandDispatcher<S> {
         return execute(parse, this.stack);
     }
 
+    public DispatchingState<S> executeCumulative(final ParseResults<S> parse) throws CommandSyntaxException {
+        return executeCumulative(parse, this.stack);
+    }
+
     /**
      * Executes a parsed command for a specific dispatching stack.
      *
@@ -218,12 +231,13 @@ public class CommandDispatcher<S> {
      * @throws CommandSyntaxException if the command failed to parse or execute
      */
     public int execute(final ParseResults<S> parse, final DispatchingStack<S> stack) throws CommandSyntaxException {
+        return executeCumulative(parse, stack).getReturnValue();
+    }
+
+    public DispatchingState<S> executeCumulative(final ParseResults<S> parse, final DispatchingStack<S> stack) throws CommandSyntaxException {
         final DispatchingState<S> state = stack.addCommand(parse, consumer);
         stack.execute();
-        final CommandSyntaxException ex = state.getException();
-        if (ex != null)
-            throw ex;
-        return state.getReturnValue();
+        return state;
     }
 
     /**

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -4,7 +4,6 @@
 package com.mojang.brigadier;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.context.SuggestionContext;
 import com.mojang.brigadier.dispatching.DispatchingStack;

--- a/src/main/java/com/mojang/brigadier/RecursiveCommand.java
+++ b/src/main/java/com/mojang/brigadier/RecursiveCommand.java
@@ -5,12 +5,13 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 public interface RecursiveCommand<S, I> extends Command<S> {
 
+    @Deprecated
     @Override
-    default int run(CommandContext<S> context) throws CommandSyntaxException {
+    default int run(final CommandContext<S> context) throws CommandSyntaxException {
         return finish(context, start(context));
     }
 
-    I start(CommandContext<S> context) throws CommandSyntaxException;
+    I start(final CommandContext<S> context) throws CommandSyntaxException;
 
-    int finish(CommandContext<S> context, I intermediate) throws CommandSyntaxException;
+    int finish(final CommandContext<S> context, I intermediate) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/RecursiveCommand.java
+++ b/src/main/java/com/mojang/brigadier/RecursiveCommand.java
@@ -1,0 +1,16 @@
+package com.mojang.brigadier;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+public interface RecursiveCommand<S, I> extends Command<S> {
+
+    @Override
+    default int run(CommandContext<S> context) throws CommandSyntaxException {
+        return finish(context, start(context));
+    }
+
+    I start(CommandContext<S> context) throws CommandSyntaxException;
+
+    int finish(CommandContext<S> context, I intermediate) throws CommandSyntaxException;
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
@@ -13,15 +13,14 @@ import java.util.Collection;
 import java.util.Deque;
 
 final class CommandContextFrame<S> implements Frame<S> {
-
     private final CommandContext<S> context;
 
-    CommandContextFrame(CommandContext<S> context) {
+    CommandContextFrame(final CommandContext<S> context) {
         this.context = context;
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
+    public void expand(final Deque<Frame<S>> waitlist, final DispatchingState<S> state) throws CommandSyntaxException {
         final CommandContext<S> child = context.getChild();
         if (child != null) {
             if (context.isForked()) {
@@ -70,7 +69,7 @@ final class CommandContextFrame<S> implements Frame<S> {
     }
 
     // bypasses generic limits
-    private <I> void addRecursiveCommand(Deque<Frame<S>> waitlist, RecursiveCommand<S, I> command) throws CommandSyntaxException {
+    private <I> void addRecursiveCommand(final Deque<Frame<S>> waitlist, final RecursiveCommand<S, I> command) throws CommandSyntaxException {
         waitlist.addLast(new RecursiveCommandReturnFrame<>(context, command.start(context), command));
     }
 }

--- a/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
@@ -18,14 +18,14 @@ final class CommandContextFrame<S> implements Frame<S> {
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
         final CommandContext<S> child = context.getChild();
         if (child != null) {
             if (context.isForked()) {
-                result.setForked();
+                state.setForked();
             }
             if (child.hasNodes()) {
-                result.foundCommand();
+                state.foundCommand();
                 final RedirectModifier<S> modifier = context.getRedirectModifier();
                 if (modifier == null) {
                     waitlist.add(new CommandContextFrame<>(child.copyFor(context.getSource())));
@@ -38,28 +38,28 @@ final class CommandContextFrame<S> implements Frame<S> {
                             }
                         }
                     } catch (final CommandSyntaxException ex) {
-                        result.getConsumer().onCommandComplete(context, false, 0);
-                        if (!result.isForked()) {
+                        state.getConsumer().onCommandComplete(context, false, 0);
+                        if (!state.isForked()) {
                             throw ex;
                         }
                     }
                 }
             }
         } else if (context.getCommand() != null) {
-            result.foundCommand();
+            state.foundCommand();
             try {
                 final Command<S> cmd = context.getCommand();
                 if (cmd instanceof RecursiveCommand) {
                     addRecursiveCommand(waitlist, (RecursiveCommand<S, ?>) cmd);
                 } else {
                     final int value = cmd.run(context);
-                    result.addResult(value);
-                    result.getConsumer().onCommandComplete(context, true, value);
-                    result.addFork();
+                    state.addResult(value);
+                    state.getConsumer().onCommandComplete(context, true, value);
+                    state.addFork();
                 }
             } catch (final CommandSyntaxException ex) {
-                result.getConsumer().onCommandComplete(context, false, 0);
-                if (!result.isForked()) {
+                state.getConsumer().onCommandComplete(context, false, 0);
+                if (!state.isForked()) {
                     throw ex;
                 }
             }

--- a/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
@@ -1,0 +1,73 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.RecursiveCommand;
+import com.mojang.brigadier.RedirectModifier;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import java.util.Collection;
+import java.util.Deque;
+
+final class CommandContextFrame<S> implements Frame<S> {
+
+    private final CommandContext<S> context;
+
+    CommandContextFrame(CommandContext<S> context) {
+        this.context = context;
+    }
+
+    @Override
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+        final CommandContext<S> child = context.getChild();
+        if (child != null) {
+            if (context.isForked()) {
+                result.setForked();
+            }
+            if (child.hasNodes()) {
+                result.foundCommand();
+                final RedirectModifier<S> modifier = context.getRedirectModifier();
+                if (modifier == null) {
+                    waitlist.add(new CommandContextFrame<>(child.copyFor(context.getSource())));
+                } else {
+                    try {
+                        final Collection<S> results = modifier.apply(context);
+                        if (!results.isEmpty()) {
+                            for (final S source : results) {
+                                waitlist.add(new CommandContextFrame<>(child.copyFor(source)));
+                            }
+                        }
+                    } catch (final CommandSyntaxException ex) {
+                        result.getConsumer().onCommandComplete(context, false, 0);
+                        if (!result.isForked()) {
+                            throw ex;
+                        }
+                    }
+                }
+            }
+        } else if (context.getCommand() != null) {
+            result.foundCommand();
+            try {
+                final Command<S> cmd = context.getCommand();
+                if (cmd instanceof RecursiveCommand) {
+                    addRecursiveCommand(waitlist, (RecursiveCommand<S, ?>) cmd);
+                } else {
+                    final int value = cmd.run(context);
+                    result.addResult(value);
+                    result.getConsumer().onCommandComplete(context, true, value);
+                    result.addFork();
+                }
+            } catch (final CommandSyntaxException ex) {
+                result.getConsumer().onCommandComplete(context, false, 0);
+                if (!result.isForked()) {
+                    throw ex;
+                }
+            }
+        }
+    }
+
+    // bypasses generic limits
+    private <I> void addRecursiveCommand(Deque<Frame<S>> waitlist, RecursiveCommand<S, I> command) throws CommandSyntaxException {
+        waitlist.addLast(new RecursiveCommandReturnFrame<>(context, command.start(context), command));
+    }
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/CommandContextFrame.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.Command;

--- a/src/main/java/com/mojang/brigadier/dispatching/DispatchingStack.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/DispatchingStack.java
@@ -1,0 +1,91 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.ResultConsumer;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public final class DispatchingStack<S> {
+
+    private final Deque<Frame<S>> stack = new ArrayDeque<>();
+    private final Deque<Frame<S>> waitlist = new ArrayDeque<>();
+    private DispatchingState<S> currentState = new DispatchingState<>((a, b, c) -> {
+    });
+    private boolean executing;
+
+    public DispatchingStack() {
+        this.executing = false;
+    }
+
+    DispatchingState<S> getCurrentState() {
+        return this.currentState;
+    }
+
+    void setCurrentState(DispatchingState<S> state) {
+        this.currentState = state;
+    }
+
+    public DispatchingState<S> addCommand(ParseResults<S> parse, ResultConsumer<S> consumer) throws CommandSyntaxException {
+        if (parse.getReader().canRead()) {
+            if (parse.getExceptions().size() == 1) {
+                throw parse.getExceptions().values().iterator().next();
+            } else if (parse.getContext().getRange().isEmpty()) {
+                throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand().createWithContext(parse.getReader());
+            } else {
+                throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownArgument().createWithContext(parse.getReader());
+            }
+        }
+
+        DispatchingState<S> collectingState = new DispatchingState<>(consumer);
+        waitlist.addLast(new ParsedResultFrame<>(parse, collectingState, this));
+
+        return collectingState;
+    }
+
+    public boolean isExecuting() {
+        return this.executing;
+    }
+
+    public void execute() throws CommandSyntaxException {
+        if (this.executing)
+            return;
+        this.executing = true;
+        while (true) {
+            while (!waitlist.isEmpty()) {
+                stack.addFirst(waitlist.removeLast());
+            }
+
+            if (stack.isEmpty()) {
+                break;
+            }
+
+            Frame<S> frame = stack.removeFirst();
+            try {
+                frame.expand(waitlist, currentState);
+            } catch (CommandSyntaxException ex) {
+                waitlist.clear();
+                CommandSyntaxException currentException = ex;
+                while (!stack.isEmpty() && currentException != null) {
+                    Frame<S> top = stack.removeFirst();
+                    if (top instanceof ExceptionHandlerFrame) {
+                        try {
+                            ((ExceptionHandlerFrame<S>) top).handleException(ex, currentState);
+                            currentException = null;
+                        } catch (CommandSyntaxException ex2) {
+                            currentException = ex2;
+                        }
+                    }
+                }
+
+                if (currentException != null) {
+                    throw currentException;
+                }
+            }
+        }
+        this.executing = false;
+    }
+
+
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/DispatchingStack.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/DispatchingStack.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.ParseResults;

--- a/src/main/java/com/mojang/brigadier/dispatching/DispatchingStack.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/DispatchingStack.java
@@ -11,7 +11,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 public final class DispatchingStack<S> {
-
     private final Deque<Frame<S>> stack = new ArrayDeque<>();
     private final Deque<Frame<S>> waitlist = new ArrayDeque<>();
     private DispatchingState<S> currentState = new DispatchingState<>((a, b, c) -> {
@@ -26,11 +25,11 @@ public final class DispatchingStack<S> {
         return this.currentState;
     }
 
-    void setCurrentState(DispatchingState<S> state) {
+    void setCurrentState(final DispatchingState<S> state) {
         this.currentState = state;
     }
 
-    public DispatchingState<S> addCommand(ParseResults<S> parse, ResultConsumer<S> consumer) throws CommandSyntaxException {
+    public DispatchingState<S> addCommand(final ParseResults<S> parse, final ResultConsumer<S> consumer) throws CommandSyntaxException {
         if (parse.getReader().canRead()) {
             if (parse.getExceptions().size() == 1) {
                 throw parse.getExceptions().values().iterator().next();
@@ -41,7 +40,7 @@ public final class DispatchingStack<S> {
             }
         }
 
-        DispatchingState<S> collectingState = new DispatchingState<>(consumer);
+        final DispatchingState<S> collectingState = new DispatchingState<>(consumer);
         waitlist.addLast(new ParsedResultFrame<>(parse, collectingState, this));
 
         return collectingState;
@@ -64,19 +63,19 @@ public final class DispatchingStack<S> {
                 break;
             }
 
-            Frame<S> frame = stack.removeFirst();
+            final Frame<S> frame = stack.removeFirst();
             try {
                 frame.expand(waitlist, currentState);
-            } catch (CommandSyntaxException ex) {
+            } catch (final CommandSyntaxException ex) {
                 waitlist.clear();
                 CommandSyntaxException currentException = ex;
                 while (!stack.isEmpty() && currentException != null) {
-                    Frame<S> top = stack.removeFirst();
+                    final Frame<S> top = stack.removeFirst();
                     if (top instanceof ExceptionHandlerFrame) {
                         try {
                             ((ExceptionHandlerFrame<S>) top).handleException(ex, currentState);
                             currentException = null;
-                        } catch (CommandSyntaxException ex2) {
+                        } catch (final CommandSyntaxException ex2) {
                             currentException = ex2;
                         }
                     }
@@ -89,6 +88,4 @@ public final class DispatchingStack<S> {
         }
         this.executing = false;
     }
-
-
 }

--- a/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
@@ -1,0 +1,61 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.ResultConsumer;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+public final class DispatchingState<S> {
+    private int result = 0;
+    private int successfulForks = 0;
+    private boolean forked = false;
+    private boolean foundCommands = false;
+    private final ResultConsumer<S> consumer;
+    private CommandSyntaxException exception;
+
+    DispatchingState(ResultConsumer<S> consumer) {
+        this.consumer = consumer;
+    }
+
+    public void addResult(int result) {
+        this.result += result;
+    }
+
+    public void setForked() {
+        this.forked = true;
+    }
+
+    public void addFork() {
+        this.successfulForks++;
+    }
+
+    public void foundCommand() {
+        this.foundCommands = true;
+    }
+
+    public int getReturnValue() {
+        return forked ? successfulForks : result;
+    }
+
+    public int getResult() {
+        return result;
+    }
+
+    public boolean isForked() {
+        return forked;
+    }
+
+    public boolean hasFoundCommands() {
+        return foundCommands;
+    }
+
+    public ResultConsumer<S> getConsumer() {
+        return this.consumer;
+    }
+
+    public void setException(CommandSyntaxException ex) {
+        this.exception = ex;
+    }
+
+    public CommandSyntaxException getException() {
+        return this.exception;
+    }
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.ResultConsumer;

--- a/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
@@ -12,7 +12,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
  * @param <S> the command source type
  */
 public final class DispatchingState<S> {
-
     private int result = 0;
     private int successfulForks = 0;
     private boolean forked = false;
@@ -20,7 +19,7 @@ public final class DispatchingState<S> {
     private CommandSyntaxException exception;
     private final ResultConsumer<S> consumer;
 
-    DispatchingState(ResultConsumer<S> consumer) {
+    DispatchingState(final ResultConsumer<S> consumer) {
         this.consumer = consumer;
     }
 
@@ -37,7 +36,7 @@ public final class DispatchingState<S> {
         return forked ? successfulForks : result;
     }
 
-    void addResult(int result) {
+    void addResult(final int result) {
         this.result += result;
     }
 
@@ -69,7 +68,7 @@ public final class DispatchingState<S> {
         return this.consumer;
     }
 
-    void setException(CommandSyntaxException ex) {
+    void setException(final CommandSyntaxException ex) {
         this.exception = ex;
     }
 

--- a/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/DispatchingState.java
@@ -3,59 +3,74 @@ package com.mojang.brigadier.dispatching;
 import com.mojang.brigadier.ResultConsumer;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
+/**
+ * A cumulative dispatching result that is in progress of collection.
+ *
+ * @param <S> the command source type
+ */
 public final class DispatchingState<S> {
+
     private int result = 0;
     private int successfulForks = 0;
     private boolean forked = false;
     private boolean foundCommands = false;
-    private final ResultConsumer<S> consumer;
     private CommandSyntaxException exception;
+    private final ResultConsumer<S> consumer;
 
     DispatchingState(ResultConsumer<S> consumer) {
         this.consumer = consumer;
     }
 
-    public void addResult(int result) {
-        this.result += result;
-    }
-
-    public void setForked() {
-        this.forked = true;
-    }
-
-    public void addFork() {
-        this.successfulForks++;
-    }
-
-    public void foundCommand() {
-        this.foundCommands = true;
-    }
-
-    public int getReturnValue() {
+    /**
+     * Gets the current return value of the dispatching state.
+     *
+     * @return the current result of the dispatching state
+     * @throws CommandSyntaxException if the state has observed an exception
+     */
+    public int getReturnValue() throws CommandSyntaxException {
+        if (exception != null) {
+            throw exception;
+        }
         return forked ? successfulForks : result;
     }
 
-    public int getResult() {
+    void addResult(int result) {
+        this.result += result;
+    }
+
+    void setForked() {
+        this.forked = true;
+    }
+
+    void addFork() {
+        this.successfulForks++;
+    }
+
+    void foundCommand() {
+        this.foundCommands = true;
+    }
+
+    int getResult() {
         return result;
     }
 
-    public boolean isForked() {
+    boolean isForked() {
         return forked;
     }
 
-    public boolean hasFoundCommands() {
+    boolean hasFoundCommands() {
         return foundCommands;
     }
 
-    public ResultConsumer<S> getConsumer() {
+    ResultConsumer<S> getConsumer() {
         return this.consumer;
     }
 
-    public void setException(CommandSyntaxException ex) {
+    void setException(CommandSyntaxException ex) {
         this.exception = ex;
     }
 
-    public CommandSyntaxException getException() {
+    CommandSyntaxException getException() {
         return this.exception;
     }
 }

--- a/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
@@ -2,7 +2,18 @@ package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
-public interface ExceptionHandlerFrame<S> extends Frame<S> {
+import java.util.Deque;
 
+interface ExceptionHandlerFrame<S> extends Frame<S> {
+
+    /**
+     * Handles a command exception thrown in a deeper frame.
+     *
+     * <p>Note: {@link #expand(Deque, DispatchingState)} call will be skipped when the exception is handled.</p>
+     *
+     * @param ex the exception to handle
+     * @param result the current dispatching state in the stack
+     * @throws CommandSyntaxException if a new exception emerges or if this handler wants to rethrow the exception
+     */
     void handleException(CommandSyntaxException ex, DispatchingState<S> result) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
@@ -1,0 +1,8 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+public interface ExceptionHandlerFrame<S> extends Frame<S> {
+
+    void handleException(CommandSyntaxException ex, DispatchingState<S> result) throws CommandSyntaxException;
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ExceptionHandlerFrame.java
@@ -8,7 +8,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Deque;
 
 interface ExceptionHandlerFrame<S> extends Frame<S> {
-
     /**
      * Handles a command exception thrown in a deeper frame.
      *
@@ -18,5 +17,5 @@ interface ExceptionHandlerFrame<S> extends Frame<S> {
      * @param result the current dispatching state in the stack
      * @throws CommandSyntaxException if a new exception emerges or if this handler wants to rethrow the exception
      */
-    void handleException(CommandSyntaxException ex, DispatchingState<S> result) throws CommandSyntaxException;
+    void handleException(final CommandSyntaxException ex, final DispatchingState<S> result) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/dispatching/Frame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/Frame.java
@@ -7,6 +7,15 @@ import java.util.Deque;
 @FunctionalInterface
 interface Frame<S> {
 
-    void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException;
+    /**
+     * Executes the frame and add more frames as necessary.
+     *
+     * <p>When adding frames, please add to the end of the waitlist.</p>
+     *
+     * @param waitlist the collection to add more frames to
+     * @param state the current dispatching state
+     * @throws CommandSyntaxException if an exception emerges during execution
+     */
+    void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException;
 
 }

--- a/src/main/java/com/mojang/brigadier/dispatching/Frame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/Frame.java
@@ -9,7 +9,6 @@ import java.util.Deque;
 
 @FunctionalInterface
 interface Frame<S> {
-
     /**
      * Executes the frame and add more frames as necessary.
      *
@@ -19,6 +18,5 @@ interface Frame<S> {
      * @param state the current dispatching state
      * @throws CommandSyntaxException if an exception emerges during execution
      */
-    void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException;
-
+    void expand(final Deque<Frame<S>> waitlist, final DispatchingState<S> state) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/dispatching/Frame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/Frame.java
@@ -1,0 +1,12 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import java.util.Deque;
+
+@FunctionalInterface
+interface Frame<S> {
+
+    void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException;
+
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/Frame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/Frame.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
@@ -1,0 +1,30 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import java.util.Deque;
+
+final class ParsedResultFrame<S> implements Frame<S> {
+    private final ParseResults<S> parse;
+    private final DispatchingState<S> collectingState;
+    private final DispatchingStack<S> stack;
+
+    ParsedResultFrame(ParseResults<S> parse, DispatchingState<S> state, DispatchingStack<S> stack) {
+        this.parse = parse;
+        this.collectingState = state;
+        this.stack = stack;
+    }
+
+    @Override
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+        final String command = parse.getReader().getString();
+        final CommandContext<S> original = parse.getContext().build(command);
+
+        DispatchingState<S> old = stack.getCurrentState();
+        stack.setCurrentState(collectingState);
+        waitlist.addLast(new CommandContextFrame<>(original));
+        waitlist.addLast(new StateCollectionFrame<>(original, parse.getReader(), stack, old));
+    }
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
@@ -14,18 +14,18 @@ final class ParsedResultFrame<S> implements Frame<S> {
     private final DispatchingState<S> collectingState;
     private final DispatchingStack<S> stack;
 
-    ParsedResultFrame(ParseResults<S> parse, DispatchingState<S> state, DispatchingStack<S> stack) {
+    ParsedResultFrame(final ParseResults<S> parse, final DispatchingState<S> state, final DispatchingStack<S> stack) {
         this.parse = parse;
         this.collectingState = state;
         this.stack = stack;
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
+    public void expand(final Deque<Frame<S>> waitlist, final DispatchingState<S> state) throws CommandSyntaxException {
         final String command = parse.getReader().getString();
         final CommandContext<S> original = parse.getContext().build(command);
 
-        DispatchingState<S> old = stack.getCurrentState();
+        final DispatchingState<S> old = stack.getCurrentState();
         stack.setCurrentState(collectingState);
         waitlist.addLast(new CommandContextFrame<>(original));
         waitlist.addLast(new StateCollectionFrame<>(original, parse.getReader(), stack, old));

--- a/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
@@ -18,7 +18,7 @@ final class ParsedResultFrame<S> implements Frame<S> {
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
         final String command = parse.getReader().getString();
         final CommandContext<S> original = parse.getContext().build(command);
 

--- a/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.ParseResults;

--- a/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/ParsedResultFrame.java
@@ -21,7 +21,7 @@ final class ParsedResultFrame<S> implements Frame<S> {
     }
 
     @Override
-    public void expand(final Deque<Frame<S>> waitlist, final DispatchingState<S> state) throws CommandSyntaxException {
+    public void expand(final Deque<Frame<S>> waitlist, final DispatchingState<S> state) {
         final String command = parse.getReader().getString();
         final CommandContext<S> original = parse.getContext().build(command);
 

--- a/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
@@ -1,0 +1,35 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.RecursiveCommand;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import java.util.Deque;
+
+final class RecursiveCommandReturnFrame<S, I> implements Frame<S> {
+
+    private final CommandContext<S> context;
+    private final I intermediate;
+    private final RecursiveCommand<S, I> command;
+
+    RecursiveCommandReturnFrame(CommandContext<S> context, I intermediate, RecursiveCommand<S, I> recursiveCommand) {
+        this.command = recursiveCommand;
+        this.context = context;
+        this.intermediate = intermediate;
+    }
+
+    @Override
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+        try {
+            final int value = command.finish(context, intermediate);
+            result.addResult(value);
+            result.getConsumer().onCommandComplete(context, true, value);
+            result.addFork();
+        } catch (final CommandSyntaxException ex) {
+            result.getConsumer().onCommandComplete(context, false, 0);
+            if (!result.isForked()) {
+                throw ex;
+            }
+        }
+    }
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
@@ -10,19 +10,18 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Deque;
 
 final class RecursiveCommandReturnFrame<S, I> implements Frame<S> {
-
     private final CommandContext<S> context;
     private final I intermediate;
     private final RecursiveCommand<S, I> command;
 
-    RecursiveCommandReturnFrame(CommandContext<S> context, I intermediate, RecursiveCommand<S, I> recursiveCommand) {
+    RecursiveCommandReturnFrame(final CommandContext<S> context, final I intermediate, final RecursiveCommand<S, I> recursiveCommand) {
         this.command = recursiveCommand;
         this.context = context;
         this.intermediate = intermediate;
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
+    public void expand(final Deque<Frame<S>> waitlist, final DispatchingState<S> state) throws CommandSyntaxException {
         try {
             final int value = command.finish(context, intermediate);
             state.addResult(value);

--- a/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.RecursiveCommand;

--- a/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/RecursiveCommandReturnFrame.java
@@ -19,15 +19,15 @@ final class RecursiveCommandReturnFrame<S, I> implements Frame<S> {
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
         try {
             final int value = command.finish(context, intermediate);
-            result.addResult(value);
-            result.getConsumer().onCommandComplete(context, true, value);
-            result.addFork();
+            state.addResult(value);
+            state.getConsumer().onCommandComplete(context, true, value);
+            state.addFork();
         } catch (final CommandSyntaxException ex) {
-            result.getConsumer().onCommandComplete(context, false, 0);
-            if (!result.isForked()) {
+            state.getConsumer().onCommandComplete(context, false, 0);
+            if (!state.isForked()) {
                 throw ex;
             }
         }

--- a/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.ImmutableStringReader;

--- a/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
@@ -4,20 +4,18 @@
 package com.mojang.brigadier.dispatching;
 
 import com.mojang.brigadier.ImmutableStringReader;
-import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import java.util.Deque;
 
 final class StateCollectionFrame<S> implements ExceptionHandlerFrame<S> {
-
     private final CommandContext<S> original;
     private final ImmutableStringReader reader;
     private final DispatchingStack<S> stack;
     private final DispatchingState<S> lastState;
 
-    StateCollectionFrame(CommandContext<S> original, ImmutableStringReader reader, DispatchingStack<S> stack, DispatchingState<S> lastState) {
+    StateCollectionFrame(final CommandContext<S> original, final ImmutableStringReader reader, final DispatchingStack<S> stack, final DispatchingState<S> lastState) {
         this.original = original;
         this.reader = reader;
         this.stack = stack;
@@ -25,7 +23,7 @@ final class StateCollectionFrame<S> implements ExceptionHandlerFrame<S> {
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
+    public void expand(final Deque<Frame<S>> waitlist, final DispatchingState<S> state) throws CommandSyntaxException {
         stack.setCurrentState(lastState);
         if (!state.hasFoundCommands()) {
             state.getConsumer().onCommandComplete(original, false, 0);
@@ -34,7 +32,7 @@ final class StateCollectionFrame<S> implements ExceptionHandlerFrame<S> {
     }
 
     @Override
-    public void handleException(CommandSyntaxException ex, DispatchingState<S> result) throws CommandSyntaxException {
+    public void handleException(final CommandSyntaxException ex, final DispatchingState<S> result) {
         result.setException(ex);
         stack.setCurrentState(lastState);
     }

--- a/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
@@ -1,0 +1,38 @@
+package com.mojang.brigadier.dispatching;
+
+import com.mojang.brigadier.ImmutableStringReader;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import java.util.Deque;
+
+final class StateCollectionFrame<S> implements ExceptionHandlerFrame<S> {
+
+    private final CommandContext<S> original;
+    private final ImmutableStringReader reader;
+    private final DispatchingStack<S> stack;
+    private final DispatchingState<S> lastState;
+
+    StateCollectionFrame(CommandContext<S> original, ImmutableStringReader reader, DispatchingStack<S> stack, DispatchingState<S> lastState) {
+        this.original = original;
+        this.reader = reader;
+        this.stack = stack;
+        this.lastState = lastState;
+    }
+
+    @Override
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+        stack.setCurrentState(lastState);
+        if (!result.hasFoundCommands()) {
+            result.getConsumer().onCommandComplete(original, false, 0);
+            throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand().createWithContext(reader);
+        }
+    }
+
+    @Override
+    public void handleException(CommandSyntaxException ex, DispatchingState<S> result) throws CommandSyntaxException {
+        result.setException(ex);
+        stack.setCurrentState(lastState);
+    }
+}

--- a/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
+++ b/src/main/java/com/mojang/brigadier/dispatching/StateCollectionFrame.java
@@ -22,10 +22,10 @@ final class StateCollectionFrame<S> implements ExceptionHandlerFrame<S> {
     }
 
     @Override
-    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> result) throws CommandSyntaxException {
+    public void expand(Deque<Frame<S>> waitlist, DispatchingState<S> state) throws CommandSyntaxException {
         stack.setCurrentState(lastState);
-        if (!result.hasFoundCommands()) {
-            result.getConsumer().onCommandComplete(original, false, 0);
+        if (!state.hasFoundCommands()) {
+            state.getConsumer().onCommandComplete(original, false, 0);
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand().createWithContext(reader);
         }
     }

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -18,6 +18,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
@@ -33,7 +34,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -407,6 +407,8 @@ public class CommandDispatcherTest {
 
     @Test
     public void testExecuteRecursiveCommand() throws Exception {
+        final List<Integer> list = Lists.newArrayList();
+        subject.setConsumer((ctx, succ, result) -> list.add(result));
         subject.register(literal("called").executes(ctx -> 67));
         subject.register(
                 literal("recursive-caller").executes(new RecursiveCommand<Object, DispatchingState<Object>>() {
@@ -439,5 +441,6 @@ public class CommandDispatcherTest {
         assertThat(subject.execute("called", source), is(67));
         assertThat(subject.execute("recursive-caller", source), is(72));
         assertThat(subject.execute("father-caller", source), is(67 * 72));
+        assertThat(list, contains(67, 67, 72, 67, 72, 67, 67 * 72));
     }
 }


### PR DESCRIPTION
## Reason
This is to better support vanilla *Minecraft* functions so that they can have a correct return result when they are nested.

This can also allow recursive commands in brigadier without concern for java heap space.

## Bugs
https://bugs.mojang.com/browse/MC-135636
https://bugs.mojang.com/browse/MC-148612

These bugs can have ugly workarounds by calling the result consumer twice (See https://github.com/liachmodded/MC-126946-128565/commit/b42d0455329408c2e2156d913be4ca2fd4255f8a#diff-e2109301c280d1578b4527aec48c2676R52), but this is the correct fix without erroneously calling result consumer multiple times.