### PR TITLE
Fix quoted strings being parsed as booleans

### DIFF
--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -233,7 +233,7 @@ public class StringReader implements ImmutableStringReader {
 
     public boolean readBoolean() throws CommandSyntaxException {
         final int start = cursor;
-        final String value = readString();
+        final String value = readUnquotedString();
         if (value.isEmpty()) {
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedBool().createWithContext(this);
         }

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -585,4 +585,16 @@ public class StringReaderTest {
             assertThat(ex.getCursor(), is(0));
         }
     }
+
+    @Test
+    public void readBoolean_quoted() throws Exception {
+        final StringReader reader = new StringReader("\"true\"");
+        try {
+            reader.readBoolean();
+            fail();
+        } catch (final CommandSyntaxException ex) {
+            assertThat(ex.getType(), is(CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedBool()));
+            assertThat(ex.getCursor(), is(0));
+        }
+    }
 }


### PR DESCRIPTION
`parseBoolean()` in `StringReader` parses specific quoted strings (e.g. `"true"`, `'false'`) as booleans, which is pretty weird.

This PR trys to fix this and adds a test for it.