### PR TITLE
Pass context to ArgumentType.parse

### DIFF
--- a/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
@@ -14,7 +14,13 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 public interface ArgumentType<T> {
-    T parse(StringReader reader) throws CommandSyntaxException;
+    default T parse(StringReader reader) throws CommandSyntaxException {
+        return null;
+    }
+
+    default <S> T parse(StringReader reader, S context) throws CommandSyntaxException {
+        return null;
+    }
 
     default <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
         return Suggestions.empty();

--- a/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
@@ -18,7 +18,7 @@ public interface ArgumentType<T> {
         return null;
     }
 
-    default <S> T parse(StringReader reader, S context) throws CommandSyntaxException {
+    default <S> T parse(StringReader reader, S source) throws CommandSyntaxException {
         return null;
     }
 

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -58,14 +58,15 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     public void parse(final StringReader reader, final CommandContextBuilder<S> contextBuilder) throws CommandSyntaxException {
         final int start = reader.getCursor();
         T result = type.parse(reader);
+
         if (result == null) {
-            // The context-unaware method was not implemented, call the context-aware method
             result = type.parse(reader, contextBuilder.getSource());
         }
+
         if (result == null) {
-            // Throw an error to avoid magic NullPointerExceptions in the user's code
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherParseException().createWithContext(reader, "Argument Type " + type.getClass().getName() + " does not implement a 'parse' method!");
         }
+
         final ParsedArgument<S, T> parsed = new ParsedArgument<>(start, reader.getCursor(), result);
 
         contextBuilder.withArgument(name, parsed);

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -54,7 +54,6 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
         return customSuggestions;
     }
 
-    // ArgumentCommandNode.java
     @Override
     public void parse(final StringReader reader, final CommandContextBuilder<S> contextBuilder) throws CommandSyntaxException {
         final int start = reader.getCursor();

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.tree;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
@@ -53,10 +54,19 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
         return customSuggestions;
     }
 
+    // ArgumentCommandNode.java
     @Override
     public void parse(final StringReader reader, final CommandContextBuilder<S> contextBuilder) throws CommandSyntaxException {
         final int start = reader.getCursor();
-        final T result = type.parse(reader);
+        T result = type.parse(reader);
+        if (result == null) {
+            // The context-unaware method was not implemented, call the context-aware method
+            result = type.parse(reader, contextBuilder.getSource());
+        }
+        if (result == null) {
+            // Throw an error to avoid magic NullPointerExceptions in the user's code
+            throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherParseException().createWithContext(reader, "Argument Type " + type.getClass().getName() + " does not implement a 'parse' method!");
+        }
         final ParsedArgument<S, T> parsed = new ParsedArgument<>(start, reader.getCursor(), result);
 
         contextBuilder.withArgument(name, parsed);


### PR DESCRIPTION
This Pull Request implements the suggestion outlined in #76 

It has been implemented to be non-breaking unless an implemented argument type can return a nullable value. Since the CommandContext is not yet available at this point in time, we can pass the command source, from which the required context can usually be extracted.