### PR TITLE
Ensure that the CompletableFuture returned by getCompletionSuggestions is always completed

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -599,16 +599,15 @@ public class CommandDispatcher<S> {
             futures[i++] = future;
         }
 
-        final CompletableFuture<Suggestions> result = new CompletableFuture<>();
-        CompletableFuture.allOf(futures).thenRun(() -> {
+        return CompletableFuture.allOf(futures).handle((voidResult, exception) -> {
             final List<Suggestions> suggestions = new ArrayList<>();
             for (final CompletableFuture<Suggestions> future : futures) {
-                suggestions.add(future.join());
+                if (!future.isCompletedExceptionally()) {
+                    suggestions.add(future.join());
+                }
             }
-            result.complete(Suggestions.merge(fullInput, suggestions));
+            return Suggestions.merge(fullInput, suggestions);
         });
-
-        return result;
     }
 
     /**


### PR DESCRIPTION
Prior to this commit, if one CompletableFuture failed to complete, the returned future would never be completed because thenRun required all futures to complete sucessfully. Code that relies on such a completion would then be left waiting ad infinitum, with the potential for a deadlock occurring if join or get is used on the future. In Minecraft, this results in client completions failing to be displayed if more than one node asks the server for results, because all but one are cancelled - an exceptional condition!

The solution I've gone for here is to just return the results of futures that completed sucessfully.

* Test added to verify behaviour when a node fails to return a completion.