### PR TITLE
StringReader: allow more escapes like JSON

### DIFF
--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -200,8 +200,37 @@ public class StringReader implements ImmutableStringReader {
         while (canRead()) {
             final char c = read();
             if (escaped) {
-                if (c == terminator || c == SYNTAX_ESCAPE) {
-                    result.append(c);
+                Character mogrified = null;
+                if (c == terminator) {
+                    mogrified = terminator;
+                } else {
+                    // Adapted from section 9 of ECMA-404:
+                    switch (c) {
+                        case SYNTAX_ESCAPE:
+                            mogrified = SYNTAX_ESCAPE;
+                            break;
+                        case '/':
+                            mogrified = '/';
+                            break;
+                        case 'b':
+                            mogrified = '\b';
+                            break;
+                        case 'f':
+                            mogrified = '\f';
+                            break;
+                        case 'n':
+                            mogrified = '\n';
+                            break;
+                        case 'r':
+                            mogrified = '\r';
+                            break;
+                        case 't':
+                            mogrified = '\t';
+                            break;
+                    }
+                }
+                if(mogrified != null) {
+                    result.append(mogrified);
                     escaped = false;
                 } else {
                     setCursor(getCursor() - 1);

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -214,9 +214,10 @@ public class StringReaderTest {
 
     @Test
     public void readQuotedString_withEscapedEscapes() throws Exception {
-        final StringReader reader = new StringReader("\"\\\\o/\"");
-        assertThat(reader.readQuotedString(), equalTo("\\o/"));
-        assertThat(reader.getRead(), equalTo("\"\\\\o/\""));
+        final String original = "\"\\n\\\\o/\"";
+        final StringReader reader = new StringReader(original);
+        assertThat(reader.readQuotedString(), equalTo("\n\\o/"));
+        assertThat(reader.getRead(), equalTo(original));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 


### PR DESCRIPTION
Currently, there is no way to specify things like newlines or tabs in strings. This fixes that!