### PR TITLE
fix typos in test method names

### DIFF
--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -204,7 +204,7 @@ public class CommandDispatcherTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testExecuteAmbiguiousParentSubcommand() throws Exception {
+    public void testExecuteAmbiguousParentSubcommand() throws Exception {
         final Command<Object> subCommand = mock(Command.class);
         when(subCommand.run(any())).thenReturn(100);
 
@@ -230,7 +230,7 @@ public class CommandDispatcherTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testExecuteAmbiguiousParentSubcommandViaRedirect() throws Exception {
+    public void testExecuteAmbiguousParentSubcommandViaRedirect() throws Exception {
         final Command<Object> subCommand = mock(Command.class);
         when(subCommand.run(any())).thenReturn(100);
 


### PR DESCRIPTION
`Ambiguious` becomes -> `Ambiguous`