### PR TITLE
Cache several common argument types

### DIFF
--- a/src/main/java/com/mojang/brigadier/arguments/BoolArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/BoolArgumentType.java
@@ -14,13 +14,14 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 public class BoolArgumentType implements ArgumentType<Boolean> {
+    private static final BoolArgumentType INSTANCE = new BoolArgumentType();
     private static final Collection<String> EXAMPLES = Arrays.asList("true", "false");
 
     private BoolArgumentType() {
     }
 
     public static BoolArgumentType bool() {
-        return new BoolArgumentType();
+        return INSTANCE;
     }
 
     public static boolean getBool(final CommandContext<?> context, final String name) {

--- a/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/DoubleArgumentType.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class DoubleArgumentType implements ArgumentType<Double> {
+    private static final DoubleArgumentType ALL = new DoubleArgumentType(-Double.MAX_VALUE, Double.MAX_VALUE);
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "-.5", "-1234.56");
 
     private final double minimum;
@@ -22,7 +23,7 @@ public class DoubleArgumentType implements ArgumentType<Double> {
     }
 
     public static DoubleArgumentType doubleArg() {
-        return doubleArg(-Double.MAX_VALUE);
+        return ALL;
     }
 
     public static DoubleArgumentType doubleArg(final double min) {

--- a/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/FloatArgumentType.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class FloatArgumentType implements ArgumentType<Float> {
+    private static final FloatArgumentType ALL = new FloatArgumentType(-Float.MAX_VALUE, Float.MAX_VALUE);
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "1.2", ".5", "-1", "-.5", "-1234.56");
 
     private final float minimum;
@@ -22,7 +23,7 @@ public class FloatArgumentType implements ArgumentType<Float> {
     }
 
     public static FloatArgumentType floatArg() {
-        return floatArg(-Float.MAX_VALUE);
+        return ALL;
     }
 
     public static FloatArgumentType floatArg(final float min) {

--- a/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/IntegerArgumentType.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class IntegerArgumentType implements ArgumentType<Integer> {
+    private static final IntegerArgumentType ALL = new IntegerArgumentType(Integer.MIN_VALUE, Integer.MAX_VALUE);
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123");
 
     private final int minimum;
@@ -22,7 +23,7 @@ public class IntegerArgumentType implements ArgumentType<Integer> {
     }
 
     public static IntegerArgumentType integer() {
-        return integer(Integer.MIN_VALUE);
+        return ALL;
     }
 
     public static IntegerArgumentType integer(final int min) {

--- a/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/LongArgumentType.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class LongArgumentType implements ArgumentType<Long> {
+    private static final LongArgumentType ALL = new LongArgumentType(Long.MIN_VALUE, Long.MAX_VALUE);
     private static final Collection<String> EXAMPLES = Arrays.asList("0", "123", "-123");
 
     private final long minimum;
@@ -22,7 +23,7 @@ public class LongArgumentType implements ArgumentType<Long> {
     }
 
     public static LongArgumentType longArg() {
-        return longArg(Long.MIN_VALUE);
+        return ALL;
     }
 
     public static LongArgumentType longArg(final long min) {

--- a/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
@@ -11,6 +11,10 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class StringArgumentType implements ArgumentType<String> {
+    private static final StringArgumentType WORD_ARGUMENT = new StringArgumentType(StringType.SINGLE_WORD);
+    private static final StringArgumentType QUOTED_ARGUMENT = new StringArgumentType(StringType.QUOTABLE_PHRASE);
+    private static final StringArgumentType GREEDY_ARGUMENT = new StringArgumentType(StringType.GREEDY_PHRASE);
+
     private final StringType type;
 
     private StringArgumentType(final StringType type) {
@@ -18,15 +22,15 @@ public class StringArgumentType implements ArgumentType<String> {
     }
 
     public static StringArgumentType word() {
-        return new StringArgumentType(StringType.SINGLE_WORD);
+        return WORD_ARGUMENT;
     }
 
     public static StringArgumentType string() {
-        return new StringArgumentType(StringType.QUOTABLE_PHRASE);
+        return QUOTED_ARGUMENT;
     }
 
     public static StringArgumentType greedyString() {
-        return new StringArgumentType(StringType.GREEDY_PHRASE);
+        return GREEDY_ARGUMENT;
     }
 
     public static String getString(final CommandContext<?> context, final String name) {


### PR DESCRIPTION
This PR caches common argument types. This has the potential to reduce memory usage simply by reusing instances in the tree. I haven't measured the true impact but it ought to be significant.