### PR TITLE
Add isNext(char) and isNext(Predicate<Character>) methods to ImmutableStringReader and StringReader

### DIFF
--- a/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
+++ b/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
@@ -24,5 +24,5 @@ public interface ImmutableStringReader {
 
     char peek(int offset);
 
-    boolean isAt(char c);
+    boolean isNext(char c);
 }

--- a/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
+++ b/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
@@ -23,4 +23,6 @@ public interface ImmutableStringReader {
     char peek();
 
     char peek(int offset);
+
+    boolean isAt(char c);
 }

--- a/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
+++ b/src/main/java/com/mojang/brigadier/ImmutableStringReader.java
@@ -3,6 +3,8 @@
 
 package com.mojang.brigadier;
 
+import java.util.function.Predicate;
+
 public interface ImmutableStringReader {
     String getString();
 
@@ -25,4 +27,6 @@ public interface ImmutableStringReader {
     char peek(int offset);
 
     boolean isNext(char c);
+
+    boolean isNext(Predicate<Character> predicate);
 }

--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -5,6 +5,8 @@ package com.mojang.brigadier;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
+import java.util.function.Predicate;
+
 public class StringReader implements ImmutableStringReader {
     private static final char SYNTAX_ESCAPE = '\\';
     private static final char SYNTAX_DOUBLE_QUOTE = '"';
@@ -81,6 +83,11 @@ public class StringReader implements ImmutableStringReader {
         return canRead() && peek() == c;
     }
 
+    @Override
+    public boolean isNext(Predicate<Character> predicate) {
+        return canRead() && predicate.test(peek());
+    }
+
     public char read() {
         return string.charAt(cursor++);
     }
@@ -98,14 +105,14 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public void skipWhitespace() {
-        while (canRead() && Character.isWhitespace(peek())) {
+        while (isNext(Character::isWhitespace)) {
             skip();
         }
     }
 
     public int readInt() throws CommandSyntaxException {
         final int start = cursor;
-        while (canRead() && isAllowedNumber(peek())) {
+        while (isNext(StringReader::isAllowedNumber)) {
             skip();
         }
         final String number = string.substring(start, cursor);
@@ -122,7 +129,7 @@ public class StringReader implements ImmutableStringReader {
 
     public long readLong() throws CommandSyntaxException {
         final int start = cursor;
-        while (canRead() && isAllowedNumber(peek())) {
+        while (isNext(StringReader::isAllowedNumber)) {
             skip();
         }
         final String number = string.substring(start, cursor);
@@ -139,7 +146,7 @@ public class StringReader implements ImmutableStringReader {
 
     public double readDouble() throws CommandSyntaxException {
         final int start = cursor;
-        while (canRead() && isAllowedNumber(peek())) {
+        while (isNext(StringReader::isAllowedNumber)) {
             skip();
         }
         final String number = string.substring(start, cursor);
@@ -156,7 +163,7 @@ public class StringReader implements ImmutableStringReader {
 
     public float readFloat() throws CommandSyntaxException {
         final int start = cursor;
-        while (canRead() && isAllowedNumber(peek())) {
+        while (isNext(StringReader::isAllowedNumber)) {
             skip();
         }
         final String number = string.substring(start, cursor);
@@ -181,7 +188,7 @@ public class StringReader implements ImmutableStringReader {
 
     public String readUnquotedString() {
         final int start = cursor;
-        while (canRead() && isAllowedInUnquotedString(peek())) {
+        while (isNext(StringReader::isAllowedInUnquotedString)) {
             skip();
         }
         return string.substring(start, cursor);

--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -76,6 +76,11 @@ public class StringReader implements ImmutableStringReader {
         return string.charAt(cursor + offset);
     }
 
+    @Override
+    public boolean isAt(char c) {
+        return canRead() && peek() == c;
+    }
+
     public char read() {
         return string.charAt(cursor++);
     }
@@ -249,7 +254,7 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public void expect(final char c) throws CommandSyntaxException {
-        if (!canRead() || peek() != c) {
+        if (!isAt(c)) {
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedSymbol().createWithContext(this, String.valueOf(c));
         }
         skip();

--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -77,7 +77,7 @@ public class StringReader implements ImmutableStringReader {
     }
 
     @Override
-    public boolean isAt(char c) {
+    public boolean isNext(char c) {
         return canRead() && peek() == c;
     }
 
@@ -254,7 +254,7 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public void expect(final char c) throws CommandSyntaxException {
-        if (!isAt(c)) {
+        if (!isNext(c)) {
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedSymbol().createWithContext(this, String.valueOf(c));
         }
         skip();

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -585,4 +585,15 @@ public class StringReaderTest {
             assertThat(ex.getCursor(), is(0));
         }
     }
+
+    @Test
+    public void isAt() {
+        final StringReader reader = new StringReader("abc");
+        assertThat(reader.isAt('a'), is(true));
+        assertThat(reader.isAt('x'), is(false));
+        reader.setCursor(2);
+        assertThat(reader.isAt('c'), is(true));
+        reader.skip();
+        assertThat(reader.isAt('c'), is(false));
+    }
 }

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -6,6 +6,8 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import org.junit.Test;
 
+import java.util.function.Predicate;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -587,7 +589,7 @@ public class StringReaderTest {
     }
 
     @Test
-    public void isAt() {
+    public void isNext() {
         final StringReader reader = new StringReader("abc");
         assertThat(reader.isNext('a'), is(true));
         assertThat(reader.isNext('x'), is(false));
@@ -595,5 +597,16 @@ public class StringReaderTest {
         assertThat(reader.isNext('c'), is(true));
         reader.skip();
         assertThat(reader.isNext('c'), is(false));
+    }
+
+    @Test
+    public void isNext_predicate() {
+        final StringReader reader = new StringReader("abc");
+        final Predicate<Character> predicate = c -> (c == 'a' || c == 'b');
+        assertThat(reader.isNext(predicate), is(true));
+        reader.setCursor(1);
+        assertThat(reader.isNext(predicate), is(true));
+        reader.setCursor(2);
+        assertThat(reader.isNext(predicate), is(false));
     }
 }

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -589,11 +589,11 @@ public class StringReaderTest {
     @Test
     public void isAt() {
         final StringReader reader = new StringReader("abc");
-        assertThat(reader.isAt('a'), is(true));
-        assertThat(reader.isAt('x'), is(false));
+        assertThat(reader.isNext('a'), is(true));
+        assertThat(reader.isNext('x'), is(false));
         reader.setCursor(2);
-        assertThat(reader.isAt('c'), is(true));
+        assertThat(reader.isNext('c'), is(true));
         reader.skip();
-        assertThat(reader.isAt('c'), is(false));
+        assertThat(reader.isNext('c'), is(false));
     }
 }


### PR DESCRIPTION
I see myself and other people use `reader.canRead() && reader.peek() == c` (or `!reader.canRead() || reader.peek() != c`) all the time. This is very tedious to do, so this adds the `isAt(char)` method to the `ImmutableStringReader` interface and `StringReader` class.
