### PR TITLE
Implement ADO pipeline build instead of TeamCity

### DIFF
--- a/.ado/build.yml
+++ b/.ado/build.yml
@@ -1,0 +1,51 @@
+name: $(Rev:r)
+
+trigger:
+  branches:
+    include:
+    - '*'
+    exclude:
+    - master
+
+pr:
+  branches:
+    include:
+    - '*'
+
+jobs:
+- job: 'Build'
+  displayName: 'Build for testing'
+
+  pool: 'MC-Build-1ES-Azure-Pipeline-Linux'
+  container: adoptopenjdk/openjdk8:latest
+
+  workspace:
+    clean: all
+
+  steps:
+  - task: Gradle@2
+    displayName: Build and Test
+    inputs:
+      workingDirectory: ''
+      gradleWrapperFile: 'gradlew'
+      gradleOptions: '-Xmx3072m'
+      options: '-PbuildNumber=0'
+      javaHomeOption: 'JDKVersion'
+      jdkUserInputPath: '/usr/java/openjdk-8'
+      testResultsFiles: '**/TEST-*.xml'
+      tasks: 'build test publish'
+
+  # This is a workaround for ComponentGovernanceComponentDetection@0 not recognizing the generated `.pom` file(s)
+  - task: Bash@3
+    displayName: Copy pom for component governance
+    inputs:
+      targetType: 'inline'
+      script: |
+        pompath=`find build/repo -name *.pom`
+        cp "${pompath}" build/pom.xml
+
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      scanType: 'Register'
+      verbosity: 'Verbose'
+      alertWarningLevel: 'High'

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -56,6 +56,7 @@ jobs:
 - job: 'Publish'
   displayName: 'Publish release'
   dependsOn: Build
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   pool: 'MC-Build-1ES-Azure-Pipeline-Linux'
 

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -1,0 +1,94 @@
+name: $(Rev:r)
+
+trigger:
+  branches:
+    include:
+    - master
+
+pr: none
+
+variables:
+  rConnection: 'mc-java-sc'
+  storageAccount: 'pistonprod'
+  keyVault: 'mc-java-vault'
+
+jobs:
+- job: 'Build'
+  displayName: 'Build for release'
+
+  pool: 'MC-Build-1ES-Azure-Pipeline-Linux'
+  container: adoptopenjdk/openjdk8:latest
+
+  workspace:
+    clean: all
+
+  steps:
+  - task: Gradle@2
+    displayName: Build and Test
+    inputs:
+      workingDirectory: ''
+      gradleWrapperFile: 'gradlew'
+      gradleOptions: '-Xmx3072m'
+      options: '-PbuildNumber=$(Build.BuildNumber)'
+      javaHomeOption: 'JDKVersion'
+      jdkUserInputPath: '/usr/java/openjdk-8'
+      testResultsFiles: '**/TEST-*.xml'
+      tasks: 'build test publish report'
+
+  # This is a workaround for ComponentGovernanceComponentDetection@0 not recognizing the generated `.pom` file(s)
+  - task: Bash@3
+    displayName: Copy pom for component governance
+    inputs:
+      targetType: 'inline'
+      script: |
+        pompath=`find build/repo -name *.pom`
+        cp "${pompath}" build/pom.xml
+
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      scanType: 'Register'
+      verbosity: 'Verbose'
+      alertWarningLevel: 'High'
+
+  - publish: 'build/repo/'
+    artifact: repo
+
+- job: 'Publish'
+  displayName: 'Publish release'
+  dependsOn: Build
+
+  pool: 'MC-Build-1ES-Azure-Pipeline-Linux'
+
+  workspace:
+    clean: all
+
+  steps:
+  - download: current
+    artifact: repo
+
+  - task: AzureKeyVault@1
+    displayName: 'Fetching secrets'
+    name: secrets
+    inputs:
+      azureSubscription: '$(rConnection)'
+      KeyVaultName: '$(keyVault)'
+      SecretsFilter: 'aws-access-key-id, aws-secret-access-key, pistonprod-access-key'
+      RunAsPreJob: false
+
+  - task: S3Upload@1
+    env:
+      AWS_ACCESS_KEY_ID: '$(aws-access-key-id)'
+      AWS_SECRET_ACCESS_KEY: '$(aws-secret-access-key)'
+    inputs:
+      bucketName: 'minecraft-libraries'
+      globExpressions: '**'
+      sourceFolder: '$(Pipeline.Workspace)/repo'
+
+  - task: AzureCLI@2
+    displayName: Azure CLI
+    inputs:
+      azureSubscription: '$(rConnection)'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        az storage blob upload-batch -s '$(Pipeline.Workspace)/repo' -d libraries --account-name $(storageAccount) --account-key $(pistonprod-access-key)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,4 @@
 import groovy.io.FileType
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
-import com.amazonaws.services.s3.AmazonS3Client
 
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
@@ -14,10 +12,6 @@ buildscript {
         maven {
             url "https://libraries.minecraft.net"
         }
-    }
-
-    dependencies {
-        classpath 'com.amazonaws:aws-java-sdk:1.11.33'
     }
 }
 
@@ -86,17 +80,11 @@ publishing {
 
 task report {
     doLast {
-        println "##teamcity[buildNumber '${project.version}']"
+        println "##vso[build.updatebuildnumber]${project.version}"
     }
 }
 
 def publishDir = file("$buildDir/repo")
-
-
-def uploadFile(s3, bucket, path, filename) {
-    println "Uploading $filename to $bucket as $path"
-    s3.putObject(bucket, path, filename)
-}
 
 clean.doLast {
     delete publishDir
@@ -114,14 +102,13 @@ if (version.endsWith("SNAPSHOT")) {
     }
 
     publish.doLast {
-        def AWSRoleARN = (System.getenv("AWS_ROLE_ARN") != null && System.getenv("AWS_ROLE_ARN") != "" ? System.getenv("AWS_ROLE_ARN") : null)
-        if (AWSRoleARN == null) throw new GradleException("AWS Role has not been configured, use the `AWS_ROLE_ARN` environment variable")
-        def auth = new STSAssumeRoleSessionCredentialsProvider.Builder(AWSRoleARN, "JavaBrigadierPublish").build()
-        def s3 = new AmazonS3Client(auth)
         publishDir.eachFileRecurse {
-            if (!it.name.contains(".xml") && !it.name.contains(".md5") && it.isFile()) {
-                def relPath = publishDir.toPath().relativize(it.toPath()).toFile().toString().replaceAll('\\\\', '/')
-                uploadFile(s3, "minecraft-libraries", relPath, it)
+            if (!it.isFile()) {
+                return
+            }
+            // Remove junk files
+            if (it.name.contains(".xml") || it.name.contains(".md5")) {
+                it.delete()
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-majorMinor: 1.0
+majorMinor: 1.1


### PR DESCRIPTION
Same as the other repos, just public.

[The ADO pipelines have disabled building from forks.](https://dev.azure.com/dev-mc/Java%20Minecraft/_build?_a=allDefinitions&path=%5CBrigadier%5C)