### PR TITLE
Default arguments in CommandContext

### DIFF
--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -10,6 +10,7 @@ import com.mojang.brigadier.tree.CommandNode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class CommandContext<S> {
 
@@ -77,12 +78,55 @@ public class CommandContext<S> {
         return source;
     }
 
+    public boolean hasArgument(final String name) {
+        return arguments.containsKey(name);
+    }
+
+    public <V> boolean hasArgumentOfType(final String name, final Class<V> clazz) {
+        final ParsedArgument<S, ?> argument = arguments.get(name);
+
+        return argument != null &&
+                PRIMITIVE_TO_WRAPPER.getOrDefault(clazz, clazz).isAssignableFrom(argument.getResult().getClass());
+    }
+
     @SuppressWarnings("unchecked")
     public <V> V getArgument(final String name, final Class<V> clazz) {
         final ParsedArgument<S, ?> argument = arguments.get(name);
 
         if (argument == null) {
             throw new IllegalArgumentException("No such argument '" + name + "' exists on this command");
+        }
+
+        final Object result = argument.getResult();
+        if (PRIMITIVE_TO_WRAPPER.getOrDefault(clazz, clazz).isAssignableFrom(result.getClass())) {
+            return (V) result;
+        } else {
+            throw new IllegalArgumentException("Argument '" + name + "' is defined as " + result.getClass().getSimpleName() + ", not " + clazz);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> V getArgumentOrDefault(final String name, final Class<V> clazz, final V defaultValue) {
+        final ParsedArgument<S, ?> argument = arguments.get(name);
+
+        if (argument == null) {
+            return defaultValue;
+        }
+
+        final Object result = argument.getResult();
+        if (PRIMITIVE_TO_WRAPPER.getOrDefault(clazz, clazz).isAssignableFrom(result.getClass())) {
+            return (V) result;
+        } else {
+            throw new IllegalArgumentException("Argument '" + name + "' is defined as " + result.getClass().getSimpleName() + ", not " + clazz);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> V getArgumentOrCompute(final String name, final Class<V> clazz, final Supplier<V> defaultSupplier) {
+        final ParsedArgument<S, ?> argument = arguments.get(name);
+
+        if (argument == null) {
+            return defaultSupplier.get();
         }
 
         final Object result = argument.getResult();

--- a/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
+++ b/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
@@ -7,7 +7,6 @@ import com.google.common.testing.EqualsTester;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.CommandNode;
-import com.mojang.brigadier.tree.RootCommandNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,9 +45,34 @@ public class CommandContextTest {
     }
 
     @Test
+    public void testHasArgument() throws Exception {
+        final CommandContext<Object> context = builder.withArgument("foo", new ParsedArgument<>(0, 1, 123)).build("123");
+        assertThat(context.hasArgument("foo"), is(true));
+        assertThat(context.hasArgument("bar"), is(false));
+    }
+
+    @Test
+    public void testHasArgumentOfType() throws Exception {
+        final CommandContext<Object> context = builder.withArgument("foo", new ParsedArgument<>(0, 1, 123)).build("123");
+        assertThat(context.hasArgumentOfType("foo", Integer.class), is(true));
+        assertThat(context.hasArgumentOfType("foo", String.class), is(false));
+        assertThat(context.hasArgumentOfType("bar", Object.class), is(false));
+    }
+
+    @Test
     public void testGetArgument() throws Exception {
         final CommandContext<Object> context = builder.withArgument("foo", new ParsedArgument<>(0, 1, 123)).build("123");
         assertThat(context.getArgument("foo", int.class), is(123));
+    }
+
+    @Test
+    public void testGetArgumentOrDefault() throws Exception {
+        assertThat(builder.build("").getArgumentOrDefault("foo", String.class, "bar"), is("bar"));
+    }
+
+    @Test
+    public void testGetArgumentOrCompute() throws Exception {
+        assertThat(builder.build("").getArgumentOrCompute("foo", String.class, () -> "bar"), is("bar"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds several methods to CommandContext to allow for testing the existence of arguments, as well as specifying default values for `getArguments`. Associated tests are also included.