### PR TITLE
Support for return values other than ints with backwards-compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ hs_err_pid*
 
 
 repo/
+
+# vscode workspace settings
+.vscode

--- a/src/main/java/com/mojang/brigadier/Command.java
+++ b/src/main/java/com/mojang/brigadier/Command.java
@@ -7,8 +7,8 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 @FunctionalInterface
-public interface Command<S> {
+public interface Command<S, R> {
     int SINGLE_SUCCESS = 1;
 
-    int run(CommandContext<S> context) throws CommandSyntaxException;
+    R run(CommandContext<S> context) throws CommandSyntaxException;
 }

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -62,7 +62,7 @@ public class CommandDispatcher<S> {
             return input != null && (input.getCommand() != null || input.getChildren().stream().anyMatch(hasCommand));
         }
     };
-    private ResultConsumer<S> consumer = (c, s, r) -> {
+    private ResultConsumer<S, Object> consumer = (c, s, r) -> {
     };
 
     /**
@@ -104,7 +104,7 @@ public class CommandDispatcher<S> {
      *
      * @param consumer the new result consumer to be called
      */
-    public void setConsumer(final ResultConsumer<S> consumer) {
+    public void setConsumer(final ResultConsumer<S, Object> consumer) {
         this.consumer = consumer;
     }
 
@@ -250,7 +250,7 @@ public class CommandDispatcher<S> {
                                     }
                                 }
                             } catch (final CommandSyntaxException ex) {
-                                consumer.onCommandComplete(context, false, 0);
+                                consumer.onCommandComplete(context, false, null);
                                 if (!forked) {
                                     throw ex;
                                 }
@@ -260,8 +260,7 @@ public class CommandDispatcher<S> {
                 } else if (context.getCommand() != null) {
                     foundCommand = true;
                     try {
-                        final int value = context.getCommand().run(context);
-                        result += value;
+                        final Object value = context.getCommand().run(context);
                         consumer.onCommandComplete(context, true, value);
                         successfulForks++;
                     } catch (final CommandSyntaxException ex) {

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -218,6 +218,7 @@ public class CommandDispatcher<S> {
         }
 
         Object result = new EmptyCommandResult();
+        int successfulForks = 0;
         boolean forked = false;
         boolean foundCommand = false;
         final String command = parse.getReader().getString();
@@ -265,6 +266,7 @@ public class CommandDispatcher<S> {
                         final Object value = context.getCommand().run(context);
                         consumer.onCommandComplete(context, true, value);
                         result = CommandResult.combine(result, value);
+                        successfulForks++;
                     } catch (final CommandSyntaxException ex) {
                         consumer.onCommandComplete(context, false, new EmptyCommandResult());
                         if (!forked) {
@@ -283,7 +285,7 @@ public class CommandDispatcher<S> {
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand().createWithContext(parse.getReader());
         }
 
-        return result;
+        return forked ? successfulForks : result;
     }
 
     /**

--- a/src/main/java/com/mojang/brigadier/ResultConsumer.java
+++ b/src/main/java/com/mojang/brigadier/ResultConsumer.java
@@ -6,6 +6,6 @@ package com.mojang.brigadier;
 import com.mojang.brigadier.context.CommandContext;
 
 @FunctionalInterface
-public interface ResultConsumer<S> {
-    void onCommandComplete(CommandContext<S> context, boolean success, int result);
+public interface ResultConsumer<S, R> {
+    void onCommandComplete(CommandContext<S> context, boolean success, R result);
 }

--- a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
@@ -15,7 +15,7 @@ import java.util.function.Predicate;
 
 public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
     private final RootCommandNode<S> arguments = new RootCommandNode<>();
-    private Command<S> command;
+    private Command<S, ?> command;
     private Predicate<S> requirement = s -> true;
     private CommandNode<S> target;
     private RedirectModifier<S> modifier = null;
@@ -43,12 +43,12 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
         return arguments.getChildren();
     }
 
-    public T executes(final Command<S> command) {
+    public <R> T executes(final Command<S, R> command) {
         this.command = command;
         return getThis();
     }
 
-    public Command<S> getCommand() {
+    public Command<S, ?> getCommand() {
         return command;
     }
 

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -28,7 +28,7 @@ public class CommandContext<S> {
 
     private final S source;
     private final String input;
-    private final Command<S> command;
+    private final Command<S, ?> command;
     private final Map<String, ParsedArgument<S, ?>> arguments;
     private final CommandNode<S> rootNode;
     private final List<ParsedCommandNode<S>> nodes;
@@ -37,7 +37,7 @@ public class CommandContext<S> {
     private final RedirectModifier<S> modifier;
     private final boolean forks;
 
-    public CommandContext(final S source, final String input, final Map<String, ParsedArgument<S, ?>> arguments, final Command<S> command, final CommandNode<S> rootNode, final List<ParsedCommandNode<S>> nodes, final StringRange range, final CommandContext<S> child, final RedirectModifier<S> modifier, boolean forks) {
+    public CommandContext(final S source, final String input, final Map<String, ParsedArgument<S, ?>> arguments, final Command<S, ?> command, final CommandNode<S> rootNode, final List<ParsedCommandNode<S>> nodes, final StringRange range, final CommandContext<S> child, final RedirectModifier<S> modifier, boolean forks) {
         this.source = source;
         this.input = input;
         this.arguments = arguments;
@@ -69,7 +69,7 @@ public class CommandContext<S> {
         return result;
     }
 
-    public Command<S> getCommand() {
+    public Command<S, ?> getCommand() {
         return command;
     }
 

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -19,7 +19,7 @@ public class CommandContextBuilder<S> {
     private final List<ParsedCommandNode<S>> nodes = new ArrayList<>();
     private final CommandDispatcher<S> dispatcher;
     private S source;
-    private Command<S> command;
+    private Command<S, ?> command;
     private CommandContextBuilder<S> child;
     private StringRange range;
     private RedirectModifier<S> modifier = null;
@@ -54,7 +54,7 @@ public class CommandContextBuilder<S> {
         return arguments;
     }
 
-    public CommandContextBuilder<S> withCommand(final Command<S> command) {
+    public CommandContextBuilder<S> withCommand(final Command<S, ?> command) {
         this.command = command;
         return this;
     }
@@ -95,7 +95,7 @@ public class CommandContextBuilder<S> {
         return result;
     }
 
-    public Command<S> getCommand() {
+    public Command<S, ?> getCommand() {
         return command;
     }
 

--- a/src/main/java/com/mojang/brigadier/results/CommandResult.java
+++ b/src/main/java/com/mojang/brigadier/results/CommandResult.java
@@ -1,0 +1,39 @@
+// Copyright (c) Serena Lynas. All rights reserved.
+// Licensed under the MIT license.
+
+package com.mojang.brigadier.results;
+
+/**
+ * Optional interface for CommandResult
+ * 
+ * Not all things returned from commands
+ * must implement this interface.
+ */
+public interface CommandResult {
+    /**
+     * Combine one command result with another, returning
+     * the combined result.
+     * @param other The other result to combine this result
+     * with.
+     * @return The combined result
+     */
+    default Object combine(Object other) {
+        ListCommandResult list = new ListCommandResult();
+        list.combine(this);
+        list.combine(other);
+        return list;
+    }
+
+    static Object combine(Object target, Object source) {
+        if (target instanceof CommandResult) {
+            return ((CommandResult)target).combine(source);
+        } else if (target instanceof Integer && source instanceof Integer) {
+            // Backwards compatability
+            return (Integer)target + (Integer)source;
+        } else if (source instanceof EmptyCommandResult) {
+            return target;
+        } else {
+            return source;
+        }
+    }
+}

--- a/src/main/java/com/mojang/brigadier/results/EmptyCommandResult.java
+++ b/src/main/java/com/mojang/brigadier/results/EmptyCommandResult.java
@@ -1,0 +1,19 @@
+// Copyright (c) Serena Lynas. All rights reserved.
+// Licensed under the MIT license.
+
+package com.mojang.brigadier.results;
+
+/**
+ * Empty class which semantically represents
+ * an empty command result.
+ */
+public class EmptyCommandResult implements CommandResult {
+    /**
+     * Combines this result with another. Always overwrites
+     * the empty result.
+     */
+    @Override
+    public Object combine(Object other) {
+        return other;
+    }
+}

--- a/src/main/java/com/mojang/brigadier/results/ListCommandResult.java
+++ b/src/main/java/com/mojang/brigadier/results/ListCommandResult.java
@@ -1,0 +1,24 @@
+// Copyright (c) Serena Lynas. All rights reserved.
+// Licensed under the MIT license.
+
+package com.mojang.brigadier.results;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListCommandResult implements CommandResult {
+    private List<Object> results = new ArrayList<>();
+
+    public List<Object> getResults() {
+        return results;
+    }
+
+    @Override
+    public ListCommandResult combine(Object other) {
+        if (!(other instanceof EmptyCommandResult)) {
+            results.add(other);
+        }
+
+        return this;
+    }
+}

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -28,7 +28,7 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     private final ArgumentType<T> type;
     private final SuggestionProvider<S> customSuggestions;
 
-    public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
+    public ArgumentCommandNode(final String name, final ArgumentType<T> type, final Command<S, ?> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks, final SuggestionProvider<S> customSuggestions) {
         super(command, requirement, redirect, modifier, forks);
         this.name = name;
         this.type = type;

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -31,9 +31,9 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
     private final CommandNode<S> redirect;
     private final RedirectModifier<S> modifier;
     private final boolean forks;
-    private Command<S> command;
+    private Command<S, ?> command;
 
-    protected CommandNode(final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
+    protected CommandNode(final Command<S, ?> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         this.command = command;
         this.requirement = requirement;
         this.redirect = redirect;
@@ -41,7 +41,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         this.forks = forks;
     }
 
-    public Command<S> getCommand() {
+    public Command<S, ?> getCommand() {
         return command;
     }
 

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -24,7 +24,7 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
     private final String literal;
     private final String literalLowerCase;
 
-    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
+    public LiteralCommandNode(final String literal, final Command<S, ?> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         super(command, requirement, redirect, modifier, forks);
         this.literal = literal;
         this.literalLowerCase = literal.toLowerCase(Locale.ROOT);

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 public class CommandDispatcherTest {
     private CommandDispatcher<Object> subject;
     @Mock
-    private Command<Object> command;
+    private Command<Object, Integer> command;
     @Mock
     private Object source;
 
@@ -167,7 +167,7 @@ public class CommandDispatcherTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testExecuteSubcommand() throws Exception {
-        final Command<Object> subCommand = mock(Command.class);
+        final Command<Object, Integer> subCommand = mock(Command.class);
         when(subCommand.run(any())).thenReturn(100);
 
         subject.register(literal("foo").then(
@@ -205,7 +205,7 @@ public class CommandDispatcherTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testExecuteAmbiguiousParentSubcommand() throws Exception {
-        final Command<Object> subCommand = mock(Command.class);
+        final Command<Object, Integer> subCommand = mock(Command.class);
         when(subCommand.run(any())).thenReturn(100);
 
         subject.register(
@@ -231,7 +231,7 @@ public class CommandDispatcherTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testExecuteAmbiguiousParentSubcommandViaRedirect() throws Exception {
-        final Command<Object> subCommand = mock(Command.class);
+        final Command<Object, Integer> subCommand = mock(Command.class);
         when(subCommand.run(any())).thenReturn(100);
 
         final LiteralCommandNode<Object> real = subject.register(
@@ -343,7 +343,7 @@ public class CommandDispatcherTest {
 
     @Test
     public void testExecute_invalidOther() throws Exception {
-        final Command<Object> wrongCommand = mock(Command.class);
+        final Command<Object, Integer> wrongCommand = mock(Command.class);
         subject.register(literal("w").executes(wrongCommand));
         subject.register(literal("world").executes(command));
 

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherUsagesTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherUsagesTest.java
@@ -30,7 +30,7 @@ public class CommandDispatcherUsagesTest {
     @Mock
     private Object source;
     @Mock
-    private Command<Object> command;
+    private Command<Object, Integer> command;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/com/mojang/brigadier/builder/LiteralArgumentBuilderTest.java
+++ b/src/test/java/com/mojang/brigadier/builder/LiteralArgumentBuilderTest.java
@@ -19,7 +19,7 @@ public class LiteralArgumentBuilderTest {
     private LiteralArgumentBuilder<Object> builder;
     @Mock
     private
-    Command<Object> command;
+    Command<Object, Integer> command;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/com/mojang/brigadier/builder/RequiredArgumentBuilderTest.java
+++ b/src/test/java/com/mojang/brigadier/builder/RequiredArgumentBuilderTest.java
@@ -25,7 +25,7 @@ public class RequiredArgumentBuilderTest {
     private RequiredArgumentBuilder<Object, Integer> builder;
     @Mock
     private
-    Command<Object> command;
+    Command<Object, Integer> command;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
+++ b/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
@@ -65,8 +65,8 @@ public class CommandContextTest {
     @Test
     public void testEquals() throws Exception {
         final Object otherSource = new Object();
-        final Command<Object> command = mock(Command.class);
-        final Command<Object> otherCommand = mock(Command.class);
+        final Command<Object, Integer> command = mock(Command.class);
+        final Command<Object, Integer> otherCommand = mock(Command.class);
         final CommandNode<Object> rootNode = mock(CommandNode.class);
         final CommandNode<Object> otherRootNode = mock(CommandNode.class);
         final CommandNode<Object> node = mock(CommandNode.class);

--- a/src/test/java/com/mojang/brigadier/tree/ArgumentCommandNodeTest.java
+++ b/src/test/java/com/mojang/brigadier/tree/ArgumentCommandNodeTest.java
@@ -57,7 +57,7 @@ public class ArgumentCommandNodeTest extends AbstractCommandNodeTest {
 
     @Test
     public void testEquals() throws Exception {
-        @SuppressWarnings("unchecked") final Command<Object> command = (Command<Object>) mock(Command.class);
+        @SuppressWarnings("unchecked") final Command<Object, Integer> command = (Command<Object, Integer>) mock(Command.class);
 
         new EqualsTester()
             .addEqualityGroup(

--- a/src/test/java/com/mojang/brigadier/tree/LiteralCommandNodeTest.java
+++ b/src/test/java/com/mojang/brigadier/tree/LiteralCommandNodeTest.java
@@ -100,7 +100,7 @@ public class LiteralCommandNodeTest extends AbstractCommandNodeTest {
 
     @Test
     public void testEquals() throws Exception {
-        @SuppressWarnings("unchecked") final Command<Object> command = mock(Command.class);
+        @SuppressWarnings("unchecked") final Command<Object, Integer> command = mock(Command.class);
 
         new EqualsTester()
             .addEqualityGroup(


### PR DESCRIPTION
This PR allows commands to return any object. Because of Java's autoboxing, it is mostly backwards compatible with older code which returns ints. The only breaking changes are that old user code which references `Command<S>` must be changed to `Command<S, Integer>`, and the return value from command execution is now Object, so the type needs to be checked/cast to int. Please let me know if there are any other breaking changes. I didn't change the tests aside from adding the Integer generic as mentioned above, so everything else should be the same.

I think that many users of this library will find the minimal cost of refactoring worth it given the immense benefit of returning more than just ints.