### PR TITLE
Fix for issue 109

### DIFF
--- a/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
@@ -9,14 +9,23 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 public class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumentBuilder<S>> {
     private final String literal;
 
-    private boolean isCaseInsensitive = false;
+    private final boolean ignoreCase;
 
-    protected LiteralArgumentBuilder(final String literal) {
+    public LiteralArgumentBuilder(final String literal) {
+        this(literal, false);
+    }
+
+    public LiteralArgumentBuilder(final String literal, final boolean ignoreCase) {
         this.literal = literal;
+        this.ignoreCase = ignoreCase;
     }
 
     public static <S> LiteralArgumentBuilder<S> literal(final String name) {
-        return new LiteralArgumentBuilder<>(name);
+        return new LiteralArgumentBuilder<>(name, false);
+    }
+    
+    public static <S> LiteralArgumentBuilder<S> literal(final String name, final boolean ignoreCase) {
+        return new LiteralArgumentBuilder<>(name, ignoreCase);
     }
 
     @Override
@@ -28,16 +37,11 @@ public class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumen
         return literal;
     }
 
-    public boolean isCaseInsensitive() { return isCaseInsensitive; }
-
-    public LiteralArgumentBuilder<S> caseInsensitive(boolean isCaseInsensitive) {
-        this.isCaseInsensitive = isCaseInsensitive;
-        return getThis();
-    }
+    public boolean ignoreCase() { return ignoreCase; }
 
     @Override
     public LiteralCommandNode<S> build() {
-        final LiteralCommandNode<S> result = new LiteralCommandNode<>(getLiteral(), getCommand(), getRequirement(), getRedirect(), getRedirectModifier(), isFork(), isCaseInsensitive());
+        final LiteralCommandNode<S> result = new LiteralCommandNode<>(getLiteral(), getCommand(), getRequirement(), getRedirect(), getRedirectModifier(), isFork(), ignoreCase());
 
         for (final CommandNode<S> argument : getArguments()) {
             result.addChild(argument);

--- a/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java
@@ -9,6 +9,8 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 public class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumentBuilder<S>> {
     private final String literal;
 
+    private boolean isCaseInsensitive = false;
+
     protected LiteralArgumentBuilder(final String literal) {
         this.literal = literal;
     }
@@ -26,9 +28,16 @@ public class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumen
         return literal;
     }
 
+    public boolean isCaseInsensitive() { return isCaseInsensitive; }
+
+    public LiteralArgumentBuilder<S> caseInsensitive(boolean isCaseInsensitive) {
+        this.isCaseInsensitive = isCaseInsensitive;
+        return getThis();
+    }
+
     @Override
     public LiteralCommandNode<S> build() {
-        final LiteralCommandNode<S> result = new LiteralCommandNode<>(getLiteral(), getCommand(), getRequirement(), getRedirect(), getRedirectModifier(), isFork());
+        final LiteralCommandNode<S> result = new LiteralCommandNode<>(getLiteral(), getCommand(), getRequirement(), getRedirect(), getRedirectModifier(), isFork(), isCaseInsensitive());
 
         for (final CommandNode<S> argument : getArguments()) {
             result.addChild(argument);

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.RedirectModifier;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -82,7 +83,13 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
         } else {
             children.put(node.getName(), node);
             if (node instanceof LiteralCommandNode) {
-                literals.put(node.getName(), (LiteralCommandNode<S>) node);
+                LiteralCommandNode literalNode = (LiteralCommandNode)node;
+
+                if (literalNode.isCaseInsensitive()) {
+                    literals.put(node.getName().toLowerCase(), (LiteralCommandNode<S>) node);
+                } else {
+                    literals.put(node.getName(), (LiteralCommandNode<S>) node);
+                }
             } else if (node instanceof ArgumentCommandNode) {
                 arguments.put(node.getName(), (ArgumentCommandNode<S, ?>) node);
             }
@@ -158,7 +165,13 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
             }
             final String text = input.getString().substring(cursor, input.getCursor());
             input.setCursor(cursor);
-            final LiteralCommandNode<S> literal = literals.get(text);
+
+            boolean caseInsensitive = false;
+            if (this instanceof LiteralCommandNode) {
+                caseInsensitive = ((LiteralCommandNode)this).isCaseInsensitive();
+            }
+
+            final LiteralCommandNode<S> literal = literals.get(caseInsensitive ? text.toLowerCase() : text);
             if (literal != null) {
                 return Collections.singleton(literal);
             } else {

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -23,14 +23,14 @@ import java.util.function.Predicate;
 public class LiteralCommandNode<S> extends CommandNode<S> {
     private final String literal;
     private final String literalLowerCase;
-    private boolean isCaseInsensitive = false;
+    private boolean ignoreCase;
 
     public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks,
-                              final boolean isCaseInsensitive) {
+                              final boolean ignoreCase) {
         super(command, requirement, redirect, modifier, forks);
         this.literal = literal;
         this.literalLowerCase = literal.toLowerCase(Locale.ROOT);
-        this.isCaseInsensitive = isCaseInsensitive;
+        this.ignoreCase = ignoreCase;
     }
 
     public String getLiteral() {
@@ -42,11 +42,7 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
         return literal;
     }
 
-    public boolean isCaseInsensitive() { return isCaseInsensitive; }
-
-    public void caseInsensitive(boolean isCaseInsensitive) {
-        this.isCaseInsensitive = isCaseInsensitive;
-    }
+    public boolean ignoreCase() { return ignoreCase; }
 
     @Override
     public void parse(final StringReader reader, final CommandContextBuilder<S> contextBuilder) throws CommandSyntaxException {
@@ -68,7 +64,7 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
             boolean foundMatch = false;
             String subString = reader.getString().substring(start, end);
 
-            if (isCaseInsensitive) {
+            if (ignoreCase) {
                 foundMatch = subString.equalsIgnoreCase(literal);
             } else {
                 foundMatch = subString.equals(literal);

--- a/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/LiteralCommandNode.java
@@ -23,11 +23,14 @@ import java.util.function.Predicate;
 public class LiteralCommandNode<S> extends CommandNode<S> {
     private final String literal;
     private final String literalLowerCase;
+    private boolean isCaseInsensitive = false;
 
-    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
+    public LiteralCommandNode(final String literal, final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks,
+                              final boolean isCaseInsensitive) {
         super(command, requirement, redirect, modifier, forks);
         this.literal = literal;
         this.literalLowerCase = literal.toLowerCase(Locale.ROOT);
+        this.isCaseInsensitive = isCaseInsensitive;
     }
 
     public String getLiteral() {
@@ -37,6 +40,12 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
     @Override
     public String getName() {
         return literal;
+    }
+
+    public boolean isCaseInsensitive() { return isCaseInsensitive; }
+
+    public void caseInsensitive(boolean isCaseInsensitive) {
+        this.isCaseInsensitive = isCaseInsensitive;
     }
 
     @Override
@@ -55,7 +64,17 @@ public class LiteralCommandNode<S> extends CommandNode<S> {
         final int start = reader.getCursor();
         if (reader.canRead(literal.length())) {
             final int end = start + literal.length();
-            if (reader.getString().substring(start, end).equals(literal)) {
+
+            boolean foundMatch = false;
+            String subString = reader.getString().substring(start, end);
+
+            if (isCaseInsensitive) {
+                foundMatch = subString.equalsIgnoreCase(literal);
+            } else {
+                foundMatch = subString.equals(literal);
+            }
+
+            if (foundMatch) {
                 reader.setCursor(end);
                 if (!reader.canRead() || reader.peek() == ' ') {
                     return end;

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -66,7 +66,7 @@ public class CommandDispatcherTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testCreateAndExecuteCaseInsensitiveCommand() throws Exception {
-        subject.register(literal("Foo").then(argument("bar", integer()).executes(command)).caseInsensitive(true));
+        subject.register(literal("Foo", true).then(argument("bar", integer()).executes(command)));
 
         assertThat(subject.execute("foo 123", source), is(42));
         verify(command).run(any(CommandContext.class));
@@ -83,7 +83,7 @@ public class CommandDispatcherTest {
 
     @Test
     public void testCreateAndExecuteCaseInsensitiveOffsetCommand() throws Exception {
-        subject.register(literal("Foo").executes(command).caseInsensitive(true));
+        subject.register(literal("Foo", true).executes(command));
 
         assertThat(subject.execute(inputWithOffset("/foo", 1), source), is(42));
         verify(command).run(any(CommandContext.class));

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -4,6 +4,8 @@
 package com.mojang.brigadier;
 
 import com.google.common.collect.Lists;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -63,8 +65,25 @@ public class CommandDispatcherTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void testCreateAndExecuteCaseInsensitiveCommand() throws Exception {
+        subject.register(literal("Foo").then(argument("bar", integer()).executes(command)).caseInsensitive(true));
+
+        assertThat(subject.execute("foo 123", source), is(42));
+        verify(command).run(any(CommandContext.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void testCreateAndExecuteOffsetCommand() throws Exception {
         subject.register(literal("foo").executes(command));
+
+        assertThat(subject.execute(inputWithOffset("/foo", 1), source), is(42));
+        verify(command).run(any(CommandContext.class));
+    }
+
+    @Test
+    public void testCreateAndExecuteCaseInsensitiveOffsetCommand() throws Exception {
+        subject.register(literal("Foo").executes(command).caseInsensitive(true));
 
         assertThat(subject.execute(inputWithOffset("/foo", 1), source), is(42));
         verify(command).run(any(CommandContext.class));

--- a/src/test/java/com/mojang/brigadier/tree/LiteralCommandNodeTest.java
+++ b/src/test/java/com/mojang/brigadier/tree/LiteralCommandNodeTest.java
@@ -49,14 +49,11 @@ public class LiteralCommandNodeTest extends AbstractCommandNodeTest {
 
     @Test
     public void testCaseInsensitiveParse() throws Exception {
-        try {
-            node.caseInsensitive(true);
-            final StringReader reader = new StringReader("FoO bar");
-            node.parse(reader, contextBuilder);
-            assertThat(reader.getRemaining(), equalTo(" bar"));
-        } finally {
-            node.caseInsensitive(false);
-        }
+        final LiteralCommandNode<Object> caseInsensitiveNode = literal("foo", true).build();
+
+        final StringReader reader = new StringReader("FoO bar");
+        caseInsensitiveNode.parse(reader, contextBuilder);
+        assertThat(reader.getRemaining(), equalTo(" bar"));
     }
 
     @Test

--- a/src/test/java/com/mojang/brigadier/tree/LiteralCommandNodeTest.java
+++ b/src/test/java/com/mojang/brigadier/tree/LiteralCommandNodeTest.java
@@ -48,6 +48,18 @@ public class LiteralCommandNodeTest extends AbstractCommandNodeTest {
     }
 
     @Test
+    public void testCaseInsensitiveParse() throws Exception {
+        try {
+            node.caseInsensitive(true);
+            final StringReader reader = new StringReader("FoO bar");
+            node.parse(reader, contextBuilder);
+            assertThat(reader.getRemaining(), equalTo(" bar"));
+        } finally {
+            node.caseInsensitive(false);
+        }
+    }
+
+    @Test
     public void testParseExact() throws Exception {
         final StringReader reader = new StringReader("foo");
         node.parse(reader, contextBuilder);


### PR DESCRIPTION
Literals can now be case insensitive, which can be specified with a flag in LiteralArgumentBuilder.

if the flag is true, the literal will be put into the **literals** hash in **CommandNode** with its key set to all lower case, and it will be gotten from the hash with a lowercased key.

When **CommandNode.parse** is called, it will check the flag and do a case insensitive check if necessary.