### PR TITLE
Remove the task to upload to AWS

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -77,15 +77,6 @@ jobs:
       SecretsFilter: 'aws-access-key-id, aws-secret-access-key, access-key-prod-librariesminecraftnet'
       RunAsPreJob: false
 
-  - task: S3Upload@1
-    env:
-      AWS_ACCESS_KEY_ID: '$(aws-access-key-id)'
-      AWS_SECRET_ACCESS_KEY: '$(aws-secret-access-key)'
-    inputs:
-      bucketName: 'minecraft-libraries'
-      globExpressions: '**'
-      sourceFolder: '$(Pipeline.Workspace)/repo'
-
   - task: AzureCLI@2
     displayName: Azure CLI
     inputs:


### PR DESCRIPTION
We no longer use AWS so we shouldn't upload more stuff to it.