### PR TITLE
Optimize parsing performance

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -354,13 +354,15 @@ public class CommandDispatcher<S> {
         Map<CommandNode<S>, CommandSyntaxException> errors = null;
         List<ParseResults<S>> potentials = null;
         final int cursor = originalReader.getCursor();
+        final Collection<? extends CommandNode<S>> relevantNodes = node.getRelevantNodes(originalReader);
+        final boolean unique = relevantNodes.size() == 1;
 
-        for (final CommandNode<S> child : node.getRelevantNodes(originalReader)) {
+        for (final CommandNode<S> child : relevantNodes) {
             if (!child.canUse(source)) {
                 continue;
             }
-            final CommandContextBuilder<S> context = contextSoFar.copy();
-            final StringReader reader = new StringReader(originalReader);
+            final CommandContextBuilder<S> context = unique ? contextSoFar : contextSoFar.copy();
+            final StringReader reader = unique ? originalReader : new StringReader(originalReader);
             try {
                 try {
                     child.parse(reader, context);
@@ -391,16 +393,23 @@ public class CommandDispatcher<S> {
                     return new ParseResults<>(context, parse.getReader(), parse.getExceptions());
                 } else {
                     final ParseResults<S> parse = parseNodes(child, reader, context);
+                    if (unique) {
+                        return parse;
+                    }
                     if (potentials == null) {
-                        potentials = new ArrayList<>(1);
+                        potentials = new ArrayList<>(relevantNodes.size());
                     }
                     potentials.add(parse);
                 }
             } else {
-                if (potentials == null) {
-                    potentials = new ArrayList<>(1);
+                final ParseResults<S> parse = new ParseResults<>(context, reader, Collections.emptyMap());
+                if (unique) {
+                    return parse;
                 }
-                potentials.add(new ParseResults<>(context, reader, Collections.emptyMap()));
+                if (potentials == null) {
+                    potentials = new ArrayList<>(relevantNodes.size());
+                }
+                potentials.add(parse);
             }
         }
 

--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -361,8 +361,15 @@ public class CommandDispatcher<S> {
             if (!child.canUse(source)) {
                 continue;
             }
-            final CommandContextBuilder<S> context = unique ? contextSoFar : contextSoFar.copy();
-            final StringReader reader = unique ? originalReader : new StringReader(originalReader);
+            final CommandContextBuilder<S> context;
+            final StringReader reader;
+            if (unique) {
+                context = contextSoFar;
+                reader = originalReader;
+            } else {
+                context = contextSoFar.copy();
+                reader = new StringReader(originalReader);
+            }
             try {
                 try {
                     child.parse(reader, context);

--- a/src/test/java/com/mojang/brigadier/benchmarks/ParsingBenchmarks.java
+++ b/src/test/java/com/mojang/brigadier/benchmarks/ParsingBenchmarks.java
@@ -92,6 +92,28 @@ public class ParsingBenchmarks {
             literal("k")
                 .redirect(h)
         );
+        subject.register(
+            literal("l")
+                .then(
+                    literal("1")
+                        .then(
+                            literal("2")
+                                .then(
+                                    literal("3")
+                                        .then(
+                                            literal("4")
+                                                .then(
+                                                    literal("5")
+                                                        .then(
+                                                            literal("6")
+                                                                .then(
+                                                                    literal("7")
+                                                                        .then(
+                                                                            literal("8")
+                                                                                .then(
+                                                                                    literal("9")
+                                                                                        .executes(c -> 0))))))))))
+        );
     }
 
     @Benchmark
@@ -112,5 +134,10 @@ public class ParsingBenchmarks {
     @Benchmark
     public ParseResults<Object> parse_() {
         return subject.parse("c", new Object());
+    }
+
+    @Benchmark
+    public ParseResults<Object> parse_l123456789() {
+        return subject.parse("l 1 2 3 4 5 6 7 8 9", new Object());
     }
 }

--- a/src/test/java/com/mojang/brigadier/benchmarks/ParsingBenchmarks.java
+++ b/src/test/java/com/mojang/brigadier/benchmarks/ParsingBenchmarks.java
@@ -4,6 +4,7 @@
 package com.mojang.brigadier.benchmarks;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -18,6 +19,8 @@ import java.util.concurrent.TimeUnit;
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 
 @State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class ParsingBenchmarks {
     private CommandDispatcher<Object> subject;
 
@@ -92,30 +95,22 @@ public class ParsingBenchmarks {
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
-    @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    public void parse_a1i() {
-        subject.parse("a 1 i", new Object());
+    public ParseResults<Object> parse_a1i() {
+        return subject.parse("a 1 i", new Object());
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
-    @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    public void parse_c() {
-        subject.parse("c", new Object());
+    public ParseResults<Object> parse_c() {
+        return subject.parse("c", new Object());
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
-    @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    public void parse_k1i() {
-        subject.parse("k 1 i", new Object());
+    public ParseResults<Object> parse_k1i() {
+        return subject.parse("k 1 i", new Object());
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
-    @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    public void parse_() {
-        subject.parse("c", new Object());
+    public ParseResults<Object> parse_() {
+        return subject.parse("c", new Object());
     }
 }


### PR DESCRIPTION
### Overview

This optimization avoids unnecessary object allocations by not taking snapshots of the parsing state when the size of the relevant nodes is `1`. Parsing time becomes about 48.6 to 57.1% of the original.

### Benchmark Results

#### Before Optimization f20bede62a516a11a468d27d3f1adde2085762bc

| Benchmark                            | Mode | Cnt |    Score |   Error | Units |
| :----------------------------------- | :--- | --: | -------: | ------: | :---- |
| `ParsingBenchmarks.parse_`           | avgt |  25 |  102.391 | ± 1.121 | ns/op |
| `ParsingBenchmarks.parse_a1i`        | avgt |  25 |  322.832 | ± 3.665 | ns/op |
| `ParsingBenchmarks.parse_c`          | avgt |  25 |  102.086 | ± 1.063 | ns/op |
| `ParsingBenchmarks.parse_k1i`        | avgt |  25 |  338.494 | ± 2.231 | ns/op |
| `ParsingBenchmarks.parse_l123456789` | avgt |  25 | 1014.364 | ± 9.041 | ns/op |

#### After Optimization f4d27ab04177908254b9b5d058a3ac6f9810a105

| Benchmark                            | Mode | Cnt |   Score |   Error | Units |
| :----------------------------------- | :--- | --: | ------: | ------: | :---- |
| `ParsingBenchmarks.parse_`           | avgt |  25 |  52.451 | ± 0.291 | ns/op |
| `ParsingBenchmarks.parse_a1i`        | avgt |  25 | 164.723 | ± 1.224 | ns/op |
| `ParsingBenchmarks.parse_c`          | avgt |  25 |  52.949 | ± 0.291 | ns/op |
| `ParsingBenchmarks.parse_k1i`        | avgt |  25 | 193.371 | ± 1.875 | ns/op |
| `ParsingBenchmarks.parse_l123456789` | avgt |  25 | 492.890 | ± 5.163 | ns/op |
