### PR TITLE
Allow for multiple spaces between arguments

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -383,7 +383,9 @@ public class CommandDispatcher<S> {
 
             context.withCommand(child.getCommand());
             if (reader.canRead(child.getRedirect() == null ? 2 : 1)) {
-                reader.skip();
+                do {
+                    reader.skip();
+                } while (reader.canRead() && reader.peek() == ARGUMENT_SEPARATOR_CHAR);
                 if (child.getRedirect() != null) {
                     final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor());
                     final ParseResults<S> parse = parseNodes(child.getRedirect(), reader, childContext);

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -400,6 +400,15 @@ public class CommandDispatcherTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void parse_multipleSpaceSeparator() throws Exception {
+        subject.register(literal("foo").then(literal("bar").executes(command)));
+
+        assertThat(subject.execute("foo  bar", source), is(42));
+        verify(command).run(any(CommandContext.class));
+    }
+
     @Test
     public void testExecuteInvalidSubcommand() throws Exception {
         subject.register(literal("foo").then(


### PR DESCRIPTION
This PR makes it so multiple spaces can be used between arguments. It has the advantage of not affecting greedy strings.