### PR TITLE
Preserve arguments after redirects

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -236,7 +236,7 @@ public class CommandDispatcher<S> {
                             if (next == null) {
                                 next = new ArrayList<>(1);
                             }
-                            next.add(child.copyFor(context.getSource()));
+                            next.add(child.copyFor(context.getSource()).copyWithArgumentsOf(context));
                         } else {
                             try {
                                 final Collection<S> results = modifier.apply(context);
@@ -245,7 +245,7 @@ public class CommandDispatcher<S> {
                                         next = new ArrayList<>(results.size());
                                     }
                                     for (final S source : results) {
-                                        next.add(child.copyFor(source));
+                                        next.add(child.copyFor(source).copyWithArgumentsOf(context));
                                     }
                                 } else {
                                     foundCommand = true;

--- a/src/main/java/com/mojang/brigadier/context/CommandContext.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContext.java
@@ -57,6 +57,13 @@ public class CommandContext<S> {
         return new CommandContext<>(source, input, arguments, command, rootNode, nodes, range, child, modifier, forks);
     }
 
+    public CommandContext<S> copyWithArgumentsOf(CommandContext<S> context) {
+        Map<String, ParsedArgument<S, ?>> newArguments = new HashMap<>();
+        newArguments.putAll(context.arguments);
+        newArguments.putAll(this.arguments);
+        return new CommandContext<>(source, input, newArguments, command, rootNode, nodes, range, child, modifier, forks);
+    }
+
     public CommandContext<S> getChild() {
         return child;
     }

--- a/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
+++ b/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
@@ -52,6 +52,34 @@ public class CommandContextTest {
     }
 
     @Test
+    public void testCopyArgumentsFills() throws Exception {
+        final CommandContext<Object> originalContext = new CommandContextBuilder<>(dispatcher, source, rootNode, 0).withArgument("foo", new ParsedArgument<>(0, 1, 123)).build("123");
+        final CommandContext<Object> childContext = new CommandContextBuilder<>(dispatcher, source, rootNode, 0).build("123");
+
+        final CommandContext<Object> copiedContext = childContext.copyWithArgumentsOf(originalContext);
+        assertThat(copiedContext.getArgument("foo", int.class), is(123));
+    }
+
+    @Test
+    public void testCopyArgumentsOverrides() throws Exception {
+        final CommandContext<Object> originalContext = new CommandContextBuilder<>(dispatcher, source, rootNode, 0).withArgument("foo", new ParsedArgument<>(0, 1, 123)).build("123");
+        final CommandContext<Object> childContext = new CommandContextBuilder<>(dispatcher, source, rootNode, 0).withArgument("foo", new ParsedArgument<>(0, 1, "123")).build("123");
+
+        final CommandContext<Object> copiedContext = childContext.copyWithArgumentsOf(originalContext);
+        assertThat(copiedContext.getArgument("foo", String.class), is("123"));
+    }
+
+    @Test
+    public void testCopyArgumentsMerges() throws Exception {
+        final CommandContext<Object> originalContext = new CommandContextBuilder<>(dispatcher, source, rootNode, 0).withArgument("foo", new ParsedArgument<>(0, 1, 123)).build("123");
+        final CommandContext<Object> childContext = new CommandContextBuilder<>(dispatcher, source, rootNode, 0).withArgument("bar", new ParsedArgument<>(0, 1, "123")).build("123");
+
+        final CommandContext<Object> copiedContext = childContext.copyWithArgumentsOf(originalContext);
+        assertThat(copiedContext.getArgument("foo", int.class), is(123));
+        assertThat(copiedContext.getArgument("bar", String.class), is("123"));
+    }
+
+    @Test
     public void testSource() throws Exception {
         assertThat(builder.build("").getSource(), is(source));
     }


### PR DESCRIPTION
This PR resolves #137. 

---

Previously, when executing a `CommandContext` that has a child `CommandContext` due to the parser encountering a redirected node, the arguments present in the original context would not be copied to the child context. In the example I presented in #137, the command structure looked like this:

```java
literal("command"):
    literal("high") -> argument("number", Integer from 10 to 20) (first branch) -> argument("string", greedy string) -> executor
    literal("low") -> argument("number", Integer from 0 to 10) -> redirects to (first branch) node
```

The bug I identified in #137 means that when executing the redirected branch (eg. `"command low 5 some text"`), an `IllegalArgumentException` would be thrown since the executor expects the `"number"` argument to be present in the child `CommandContext`, which is used when executing the command. I expected that the command should run without error, with the value for the `"number"` argument being `5`. In contrast, the 'real' branch would always work as expected, with the `"number"` argument present as given.

---

This PR fixes this bug by adding and using the `CommandContext#copyWithArgumentsOf` method:

```java
public CommandContext<S> copyWithArgumentsOf(CommandContext<S> context) {
    Map<String, ParsedArgument<S, ?>> newArguments = new HashMap<>();
    newArguments.putAll(context.arguments);
    newArguments.putAll(this.arguments);
    return new CommandContext<>(source, input, newArguments, command, rootNode, nodes, range, child, modifier, forks);
}
```

In my example case, the `"number" -> value: 5` argument present in the original `CommandContext` would be copied to the child `CommandContext`, so that it is present when the executor is run.

---

I added tests that directly make sure the new `CommandContext#copyWithArgumentsOf` method works as expected. I want to add tests to make sure `copyWithArgumentsOf` is being used correctly when executing commands, but I wasn't sure where to put a test like that. I wanted to make sure that I followed the code style of this repo. I'm not yet sure how the code base tests functionality like this, so I erred on the side of not adding those tests yet.

---

If you'd like to discuss whether or not the 'bug' this PR resolves is actually intended behavior, I think those comments fit best as replies to the original issue, #137. I'm honestly not sure if my issue is intended behavior or not since I couldn't find any documentation on what node redirects are supposed to do. It seems most intuitive to me that the arguments should be preserved, hence why I went through the effort to make this PR :P.