### PR TITLE
Make sure arguments are preserved after redirects

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -328,6 +328,7 @@ public class CommandDispatcher<S> {
                 reader.skip();
                 if (child.getRedirect() != null) {
                     final CommandContextBuilder<S> childContext = new CommandContextBuilder<>(this, source, child.getRedirect(), reader.getCursor());
+                    childContext.withArguments(context.getArguments());
                     final ParseResults<S> parse = parseNodes(child.getRedirect(), reader, childContext);
                     context.withChild(parse.getContext());
                     return new ParseResults<>(context, parse.getReader(), parse.getExceptions());

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -50,6 +50,11 @@ public class CommandContextBuilder<S> {
         return this;
     }
 
+    public CommandContextBuilder<S> withArguments(Map<String, ParsedArgument<S, ?>> arguments) {
+        this.arguments.putAll(arguments);
+        return this;
+    }
+
     public Map<String, ParsedArgument<S, ?>> getArguments() {
         return arguments;
     }

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -10,6 +10,7 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import org.hamcrest.CustomMatcher;
@@ -407,6 +408,22 @@ public class CommandDispatcherTest {
         subject.register(literal("baz").fork(foo, emptyModifier));
         int result = subject.execute("baz bar 100", source);
         assertThat(result, is(0)); // No commands executed, so result is 0
+    }
+
+    @Test
+    public void testRedirectPreservesPreviousArguments() throws CommandSyntaxException {
+        final LiteralCommandNode<Object> ending = literal("ending")
+                .executes(context -> context.getArgument("number", int.class)).build();
+        final ArgumentCommandNode<Object, Integer> lowNumber = argument("number", integer(1, 10))
+                .then(ending).build();
+        final ArgumentCommandNode<Object, Integer> highNumber = argument("number", integer(11, 20))
+                .redirect(lowNumber).build();
+        subject.register(literal("base")
+                .then(literal("low").then(lowNumber))
+                .then(literal("high").then(highNumber)));
+
+        assertThat(subject.execute("base low 5 ending", source), is(5));
+        assertThat(subject.execute("base high 15 ending", source), is(15));
     }
 
     @Test

--- a/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
@@ -254,6 +254,26 @@ public class CommandSuggestionsTest {
     }
 
     @Test
+    public void getCompletionSuggestions_redirectPreservesArguments() throws Exception {
+        subject.register(literal("command")
+                .then(
+                        argument("first", integer())
+                                .then(
+                                        argument("second", integer())
+                                                .suggests((context, builder) -> {
+                                                    builder.suggest(String.valueOf(context.getLastChild().getArgument("first", int.class) + 1));
+                                                    return builder.buildFuture();
+                                                })
+                                )
+                ));
+        subject.register(literal("redirect").redirect(subject.getRoot()));
+
+        testSuggestions("command 1 ", 10, StringRange.at(10), "2");
+        testSuggestions("redirect command 1 ", 19, StringRange.at(19), "2");
+        testSuggestions("redirect redirect command 1 ", 28, StringRange.at(28), "2");
+    }
+
+    @Test
     public void getCompletionSuggestions_execute_simulation() throws Exception {
         final LiteralCommandNode<Object> execute = subject.register(literal("execute"));
         subject.register(

--- a/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
+++ b/src/test/java/com/mojang/brigadier/context/CommandContextTest.java
@@ -14,6 +14,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -49,6 +52,16 @@ public class CommandContextTest {
     public void testGetArgument() throws Exception {
         final CommandContext<Object> context = builder.withArgument("foo", new ParsedArgument<>(0, 1, 123)).build("123");
         assertThat(context.getArgument("foo", int.class), is(123));
+    }
+
+    @Test
+    public void testGetArguments() throws Exception {
+        Map<String, ParsedArgument<Object, ?>> arguments = new HashMap<>();
+        arguments.put("foo", new ParsedArgument<>(0, 1, 123));
+        arguments.put("bar", new ParsedArgument<>(0, 1, "123"));
+        final CommandContext<Object> context = builder.withArguments(arguments).build("123");
+        assertThat(context.getArgument("foo", int.class), is(123));
+        assertThat(context.getArgument("bar", String.class), is("123"));
     }
 
     @Test


### PR DESCRIPTION
This PR resolves #137 and remakes #138.

---

### Summary:

When _suggesting_ arguments after a redirect, calling `CommandContext#getArgument` on the given context can only access arguments declared _before_ the redirect.

When _executing_ a command after a redirect, calling `CommandContext#getArgument` on the given context can only access arguments declared _after_ the redirect.

These two situations seem to handle arguments differently. This seems like it might be a bug, so I created #137 focusing on the problem with executing commands. It's possible this is intended behavior, but I couldn't find any documentation stating this either way. No one has confirmed or denied #137 yet, so I'm assuming this is a bug.

---

Without this PR, this example test for command dispatch fails:

```java
public class CommandDispatcherTest {
    // Setup stuff
    @Test
    public void testRedirectPreservesPreviousArguments() throws CommandSyntaxException {
        final LiteralCommandNode<Object> ending = literal("ending")
                .executes(context -> context.getArgument("number", int.class)).build();
        final ArgumentCommandNode<Object, Integer> lowNumber = argument("number", integer(1, 10))
                .then(ending).build();
        final ArgumentCommandNode<Object, Integer> highNumber = argument("number", integer(11, 20))
                .redirect(lowNumber).build();
        subject.register(literal("base")
                .then(literal("low").then(lowNumber))
                .then(literal("high").then(highNumber)));

        assertThat(subject.execute("base low 5 ending", source), is(5));
        assertThat(subject.execute("base high 15 ending", source), is(15));
    }
}
```

Specifically, the exception `java.lang.IllegalArgumentException: No such argument 'number' exists on this command` is thrown when evaluating the second assertion. When parsing `"base high 15 ending"`, a `CommandContext` something like the following is created:

```java
CommandContext {
    range: "base low 15"
    arguments: {"number"->15}
    child: CommandContext {
        range: "ending"
        arguments: {}
    }
}
```

When the command is executed, it uses the last child. This child does not know about the `number` argument, hence the `IllegalArgumentException`.

This PR makes it so that when parsing nodes redirects, the arguments from the parent `CommandContext` are copied to the child. That means parsing `"base high 15 ending"` gives the following context:
```java
CommandContext {
    range: "base low 15"
    arguments: {"number"->15}
    child: CommandContext {
        range: "ending"
        arguments: {"number"->15}
    }
}
```

So, when the last child is used to execute the command, it now knows about the `number` argument, and the executor works as expected.

---

I also thought it was weird that this example test for suggestions failed:

```java
public class CommandSuggestionsTest {
    // Setup stuff
    @Test
    public void getCompletionSuggestions_redirectPreservesArguments() throws Exception {
        subject.register(literal("command")
                .then(
                        argument("first", integer())
                                .then(
                                        argument("second", integer())
                                                .suggests((context, builder) -> {
                                                    builder.suggest(String.valueOf(context.getArgument("first", int.class) + 1));
                                                    return builder.buildFuture();
                                                })
                                )
                ));
        subject.register(literal("redirect").redirect(subject.getRoot()));

        testSuggestions("command 1 ", 10, StringRange.at(10), "2");
        testSuggestions("redirect command 1 ", 19, StringRange.at(19), "2");
        testSuggestions("redirect redirect command 1 ", 28, StringRange.at(28), "2");
    }
}
```

When creating suggestions for `"command <first> <second>"`, `<second>` is supposed to get the suggestion of `<first>+1`. This works if you just input `"command <first> "`, so the first test passes. However, after a redirect, it doesn't work. In the second test, I'd expect that `"redirect command 1 "` suggests `"2"`. However, the exception `java.lang.IllegalArgumentException: No such argument 'number' exists on this command` is thrown instead. The `CommandContext` for this would look something like this:

```java
CommandContext {
    range: "redirect"
    arguments: {}
    child: CommandContext {
        range: "command 1 "
        arguments: {"first"->1}
    }
}
```

When creating the suggestions, this whole context is used. So, just calling `CommandContext#getArgument`, the `first` argument can not be found since the parent context does not have any arguments. 

I thought this might be a bug. It makes more sense that the context representing the range that is currently being suggested should be used to get the suggestions. Here, that would mean using the `child` `CommandContext`, which does have the `first` argument. 

However, this modified test does pass:

```java
public class CommandSuggestionsTest {
    // Setup stuff
    @Test
    public void getCompletionSuggestions_redirectPreservesArguments() throws Exception {
        subject.register(literal("command")
                .then(
                        argument("first", integer())
                                .then(
                                        argument("second", integer())
                                                .suggests((context, builder) -> {
                                                    builder.suggest(String.valueOf(context.getLastChild().getArgument("first", int.class) + 1));
                                                    return builder.buildFuture();
                                                })
                                )
                ));
        subject.register(literal("redirect").redirect(subject.getRoot()));

        testSuggestions("command 1 ", 10, StringRange.at(10), "2");
        testSuggestions("redirect command 1 ", 19, StringRange.at(19), "2");
        testSuggestions("redirect redirect command 1 ", 28, StringRange.at(28), "2");
    }
}
```

Instead of using the given `CommandContext` directly, the `SuggestionsProvider` calls `CommandContext#getLastChild()`. I think this makes sense. The part of the command being suggested _should_ always be the last part of the command, and hence the last child of the `CommandContext`. This makes my test pass, so I _guess_ it's okay?

Not sure. If my assumption that the suggestions are only created at the end of the command is wrong, please correct me. In that case, I think it should be easy enough to change the suggestions code so that it choose the child `CommandContext` for the node that is currently being suggested.