### PR TITLE
[Suggestion] Allow `RequiredArgumentBuilder` to be extended

### DIFF
--- a/src/main/java/com/mojang/brigadier/builder/RequiredArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/RequiredArgumentBuilder.java
@@ -13,7 +13,7 @@ public class RequiredArgumentBuilder<S, T> extends ArgumentBuilder<S, RequiredAr
     private final ArgumentType<T> type;
     private SuggestionProvider<S> suggestionsProvider = null;
 
-    private RequiredArgumentBuilder(final String name, final ArgumentType<T> type) {
+    protected RequiredArgumentBuilder(final String name, final ArgumentType<T> type) {
         this.name = name;
         this.type = type;
     }


### PR DESCRIPTION
This PR makes `RequiredArgumentBuilder`'s constructor protected, which makes it possible to create a class that extends `RequiredArgumentBuilder`.

---

Currently, while `RequiredArgumentBuilder` is a public, non-final class, its only constructor is private:

https://github.com/Mojang/brigadier/blob/b92c420b2a292dd5c20f6adfafff5e21b9835c6d/src/main/java/com/mojang/brigadier/builder/RequiredArgumentBuilder.java#L11-L25

This makes it impossible to extend `RequiredArgumentBuilder`, since there is no valid accessible signature for the `super` call in a subclass.

On the contrary, `LiteralArgumentBuilder`'s constructor is protected:

https://github.com/Mojang/brigadier/blob/b92c420b2a292dd5c20f6adfafff5e21b9835c6d/src/main/java/com/mojang/brigadier/builder/LiteralArgumentBuilder.java#L9-L21

Subclasses are allowed to access protected members of their superclass, so it is possible to extend `LiteralArgumentBuilder`.

Since `RequiredArgumentBuilder` and `LiteralArgumentBuilder` are not final, it seems to me that were intended to be extendable.