### PR TITLE
Allow custom predicate that replaces `StringReader#isAllowedInUnquotedString`

### DIFF
--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -5,6 +5,8 @@ package com.mojang.brigadier;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
+import java.util.function.Predicate;
+
 public class StringReader implements ImmutableStringReader {
     private static final char SYNTAX_ESCAPE = '\\';
     private static final char SYNTAX_DOUBLE_QUOTE = '"';
@@ -175,8 +177,12 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public String readUnquotedString() {
+        return readUnquotedString(StringReader::isAllowedInUnquotedString);
+    }
+
+    public String readUnquotedString(Predicate<Character> allowPredicate) {
         final int start = cursor;
-        while (canRead() && isAllowedInUnquotedString(peek())) {
+        while (canRead() && allowPredicate.test(peek())) {
             skip();
         }
         return string.substring(start, cursor);
@@ -220,6 +226,10 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public String readString() throws CommandSyntaxException {
+        return readString(StringReader::isAllowedInUnquotedString);
+    }
+
+    public String readString(Predicate<Character> allowPredicate) throws CommandSyntaxException {
         if (!canRead()) {
             return "";
         }
@@ -228,7 +238,7 @@ public class StringReader implements ImmutableStringReader {
             skip();
             return readStringUntil(next);
         }
-        return readUnquotedString();
+        return readUnquotedString(allowPredicate);
     }
 
     public boolean readBoolean() throws CommandSyntaxException {

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -133,6 +133,14 @@ public class StringReaderTest {
     }
 
     @Test
+    public void readUnquotedStringCustomPredicate() throws Exception {
+        final StringReader reader = new StringReader("你好 世界");
+        assertThat(reader.readUnquotedString(c -> c >= '一' && c <= '龥'), equalTo("你好"));
+        assertThat(reader.getRead(), equalTo("你好"));
+        assertThat(reader.getRemaining(), equalTo(" 世界"));
+    }
+
+    @Test
     public void readUnquotedString_empty() throws Exception {
         final StringReader reader = new StringReader("");
         assertThat(reader.readUnquotedString(), equalTo(""));
@@ -298,6 +306,14 @@ public class StringReaderTest {
         assertThat(reader.readString(), equalTo("hello world"));
         assertThat(reader.getRead(), equalTo("\"hello world\""));
         assertThat(reader.getRemaining(), equalTo(""));
+    }
+
+    @Test
+    public void readString_customPredicate_noQuotes() throws Exception {
+        final StringReader reader = new StringReader("你好 世界");
+        assertThat(reader.readString(c -> c >= '一' && c <= '龥'), equalTo("你好"));
+        assertThat(reader.getRead(), equalTo("你好"));
+        assertThat(reader.getRemaining(), equalTo(" 世界"));
     }
 
     @Test


### PR DESCRIPTION
Instead of https://github.com/Mojang/brigadier/pull/131 with greedy charset solution, I tried another approach that allows users to define their own whitelist. It might be useful when users trying to define their own syntax on command arguments like entity selectors or something else that might accept non-ASCII characters

Usage of `StringReader#readString` or `StringReader#readUnquotedString` without any argument would lead to the default behavior, which is calling `StringReader#isAllowedInUnquotedString` as their whitelist predicate.

Fixes https://github.com/Mojang/brigadier/issues/103.