### PR TITLE
Require non-null requirements when building command nodes

### DIFF
--- a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+++ b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
@@ -11,12 +11,18 @@ import com.mojang.brigadier.tree.RootCommandNode;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
+    @SuppressWarnings("unchecked")
+    public static <S> Predicate<S> requiresNothing() {
+        return (Predicate<S>) RequiresNothing.INSTANCE;
+    }
+
     private final RootCommandNode<S> arguments = new RootCommandNode<>();
     private Command<S> command;
-    private Predicate<S> requirement = s -> true;
+    private Predicate<S> requirement = requiresNothing();
     private CommandNode<S> target;
     private RedirectModifier<S> modifier = null;
     private boolean forks;
@@ -53,7 +59,7 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
     }
 
     public T requires(final Predicate<S> requirement) {
-        this.requirement = requirement;
+        this.requirement = Objects.requireNonNull(requirement, "requirement");
         return getThis();
     }
 
@@ -96,4 +102,13 @@ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
     }
 
     public abstract CommandNode<S> build();
+
+    private static final class RequiresNothing implements Predicate<Object> {
+        private static final Predicate<Object> INSTANCE = new RequiresNothing();
+
+        @Override
+        public boolean test(final Object o) {
+            return true;
+        }
+    }
 }

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -35,7 +36,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
 
     protected CommandNode(final Command<S> command, final Predicate<S> requirement, final CommandNode<S> redirect, final RedirectModifier<S> modifier, final boolean forks) {
         this.command = command;
-        this.requirement = requirement;
+        this.requirement = Objects.requireNonNull(requirement, "requirement");
         this.redirect = redirect;
         this.modifier = modifier;
         this.forks = forks;


### PR DESCRIPTION
The requirement field is used without null checks in canUse.