### PR TITLE
Add ArgumentType.parse() overload that can accept source context

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-majorMinor: 1.2
+majorMinor: 1.3

--- a/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/ArgumentType.java
@@ -16,6 +16,10 @@ import java.util.concurrent.CompletableFuture;
 public interface ArgumentType<T> {
     T parse(StringReader reader) throws CommandSyntaxException;
 
+    default <S> T parse(final StringReader reader, final S source) throws CommandSyntaxException {
+        return parse(reader);
+    }
+
     default <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
         return Suggestions.empty();
     }

--- a/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/ArgumentCommandNode.java
@@ -56,7 +56,7 @@ public class ArgumentCommandNode<S, T> extends CommandNode<S> {
     @Override
     public void parse(final StringReader reader, final CommandContextBuilder<S> contextBuilder) throws CommandSyntaxException {
         final int start = reader.getCursor();
-        final T result = type.parse(reader);
+        final T result = type.parse(reader, contextBuilder.getSource());
         final ParsedArgument<S, T> parsed = new ParsedArgument<>(start, reader.getCursor(), result);
 
         contextBuilder.withArgument(name, parsed);


### PR DESCRIPTION
As we don't have it in all contexts, such as ambiguity detection - it's passed optionally if present through an overload.