### PR TITLE
Relax string() type and add relaxedWord()

### DIFF
--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -174,9 +174,21 @@ public class StringReader implements ImmutableStringReader {
             || c == '.' || c == '+';
     }
 
+    public static boolean isAllowedInUnquotedStringRelaxed(final char c) {
+        return c != ' ' && c != '\\' && c != '"';
+    }
+
     public String readUnquotedString() {
         final int start = cursor;
         while (canRead() && isAllowedInUnquotedString(peek())) {
+            skip();
+        }
+        return string.substring(start, cursor);
+    }
+
+    public String readUnquotedStringRelaxed() {
+        final int start = cursor;
+        while (canRead() && isAllowedInUnquotedStringRelaxed(peek())) {
             skip();
         }
         return string.substring(start, cursor);
@@ -228,7 +240,7 @@ public class StringReader implements ImmutableStringReader {
             skip();
             return readStringUntil(next);
         }
-        return readUnquotedString();
+        return readUnquotedStringRelaxed();
     }
 
     public boolean readBoolean() throws CommandSyntaxException {

--- a/src/main/java/com/mojang/brigadier/StringReader.java
+++ b/src/main/java/com/mojang/brigadier/StringReader.java
@@ -175,7 +175,7 @@ public class StringReader implements ImmutableStringReader {
     }
 
     public static boolean isAllowedInUnquotedStringRelaxed(final char c) {
-        return c != ' ' && c != '\\' && c != '"';
+        return c != ' ' && c != '\\' && !isQuotedStringStart(c);
     }
 
     public String readUnquotedString() {

--- a/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
+++ b/src/main/java/com/mojang/brigadier/arguments/StringArgumentType.java
@@ -21,7 +21,7 @@ public class StringArgumentType implements ArgumentType<String> {
         return new StringArgumentType(StringType.SINGLE_WORD);
     }
 
-    public static StringArgumentType wordRelaxed() {
+    public static StringArgumentType relaxedWord() {
         return new StringArgumentType(StringType.SINGLE_WORD_RELAXED);
     }
 

--- a/src/test/java/com/mojang/brigadier/StringReaderTest.java
+++ b/src/test/java/com/mojang/brigadier/StringReaderTest.java
@@ -149,6 +149,14 @@ public class StringReaderTest {
     }
 
     @Test
+    public void readUnquotedStringRelaxed() throws Exception {
+        final StringReader reader = new StringReader("héllö world");
+        assertThat(reader.readUnquotedStringRelaxed(), equalTo("héllö"));
+        assertThat(reader.getRead(), equalTo("héllö"));
+        assertThat(reader.getRemaining(), equalTo(" world"));
+    }
+
+    @Test
     public void readQuotedString() throws Exception {
         final StringReader reader = new StringReader("\"hello world\"");
         assertThat(reader.readQuotedString(), equalTo("hello world"));
@@ -278,25 +286,25 @@ public class StringReaderTest {
 
     @Test
     public void readString_noQuotes() throws Exception {
-        final StringReader reader = new StringReader("hello world");
-        assertThat(reader.readString(), equalTo("hello"));
-        assertThat(reader.getRead(), equalTo("hello"));
-        assertThat(reader.getRemaining(), equalTo(" world"));
+        final StringReader reader = new StringReader("héllo wörld");
+        assertThat(reader.readString(), equalTo("héllo"));
+        assertThat(reader.getRead(), equalTo("héllo"));
+        assertThat(reader.getRemaining(), equalTo(" wörld"));
     }
 
     @Test
     public void readString_singleQuotes() throws Exception {
-        final StringReader reader = new StringReader("'hello world'");
-        assertThat(reader.readString(), equalTo("hello world"));
-        assertThat(reader.getRead(), equalTo("'hello world'"));
+        final StringReader reader = new StringReader("'héllo wörld'");
+        assertThat(reader.readString(), equalTo("héllo wörld"));
+        assertThat(reader.getRead(), equalTo("'héllo wörld'"));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 
     @Test
     public void readString_doubleQuotes() throws Exception {
-        final StringReader reader = new StringReader("\"hello world\"");
-        assertThat(reader.readString(), equalTo("hello world"));
-        assertThat(reader.getRead(), equalTo("\"hello world\""));
+        final StringReader reader = new StringReader("\"héllo wörld\"");
+        assertThat(reader.readString(), equalTo("héllo wörld"));
+        assertThat(reader.getRead(), equalTo("\"héllo wörld\""));
         assertThat(reader.getRemaining(), equalTo(""));
     }
 

--- a/src/test/java/com/mojang/brigadier/arguments/StringArgumentTypeTest.java
+++ b/src/test/java/com/mojang/brigadier/arguments/StringArgumentTypeTest.java
@@ -33,10 +33,10 @@ public class StringArgumentTypeTest {
     }
 
     @Test
-    public void testParseWordRelaxed() throws Exception {
+    public void testParseRelaxedWord() throws Exception {
         final StringReader reader = mock(StringReader.class);
         when(reader.readUnquotedStringRelaxed()).thenReturn("héllo");
-        assertThat(wordRelaxed().parse(reader), equalTo("héllo"));
+        assertThat(relaxedWord().parse(reader), equalTo("héllo"));
         verify(reader).readUnquotedStringRelaxed();
     }
 

--- a/src/test/java/com/mojang/brigadier/arguments/StringArgumentTypeTest.java
+++ b/src/test/java/com/mojang/brigadier/arguments/StringArgumentTypeTest.java
@@ -10,10 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static com.mojang.brigadier.arguments.StringArgumentType.escapeIfRequired;
-import static com.mojang.brigadier.arguments.StringArgumentType.greedyString;
-import static com.mojang.brigadier.arguments.StringArgumentType.string;
-import static com.mojang.brigadier.arguments.StringArgumentType.word;
+import static com.mojang.brigadier.arguments.StringArgumentType.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
@@ -33,6 +30,14 @@ public class StringArgumentTypeTest {
         when(reader.readUnquotedString()).thenReturn("hello");
         assertThat(word().parse(reader), equalTo("hello"));
         verify(reader).readUnquotedString();
+    }
+
+    @Test
+    public void testParseWordRelaxed() throws Exception {
+        final StringReader reader = mock(StringReader.class);
+        when(reader.readUnquotedStringRelaxed()).thenReturn("héllo");
+        assertThat(wordRelaxed().parse(reader), equalTo("héllo"));
+        verify(reader).readUnquotedStringRelaxed();
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/Mojang/brigadier/issues/152
by modifying the `string()` type to be more relaxed as it already allows all characters if escape, and this just makes it more convenient to use by not requiring quoting except for white spaces, escapes and quotes.

Also adds a new string type called `relaxedWord()`. Which behaves the same as string except not allowing quoting and therefore also white spaces. `word()` is kept unchanged as this would change the possible inputs and may break things.