### PR TITLE
Fix incorrect context being used for suggestions (MC-278771)

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -538,7 +538,7 @@ public class CommandDispatcher<S> {
         for (final CommandNode<S> node : parent.getChildren()) {
             CompletableFuture<Suggestions> future = Suggestions.empty();
             try {
-                future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start));
+                future = node.listSuggestions(nodeBeforeCursor.context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start));
             } catch (final CommandSyntaxException ignored) {
             }
             futures[i++] = future;

--- a/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
+++ b/src/main/java/com/mojang/brigadier/context/CommandContextBuilder.java
@@ -122,23 +122,23 @@ public class CommandContextBuilder<S> {
                     return child.findSuggestionContext(cursor);
                 } else if (!nodes.isEmpty()) {
                     final ParsedCommandNode<S> last = nodes.get(nodes.size() - 1);
-                    return new SuggestionContext<>(last.getNode(), last.getRange().getEnd() + 1);
+                    return new SuggestionContext<>(this, last.getNode(), last.getRange().getEnd() + 1);
                 } else {
-                    return new SuggestionContext<>(rootNode, range.getStart());
+                    return new SuggestionContext<>(this, rootNode, range.getStart());
                 }
             } else {
                 CommandNode<S> prev = rootNode;
                 for (final ParsedCommandNode<S> node : nodes) {
                     final StringRange nodeRange = node.getRange();
                     if (nodeRange.getStart() <= cursor && cursor <= nodeRange.getEnd()) {
-                        return new SuggestionContext<>(prev, nodeRange.getStart());
+                        return new SuggestionContext<>(this, prev, nodeRange.getStart());
                     }
                     prev = node.getNode();
                 }
                 if (prev == null) {
                     throw new IllegalStateException("Can't find node before cursor");
                 }
-                return new SuggestionContext<>(prev, range.getStart());
+                return new SuggestionContext<>(this, prev, range.getStart());
             }
         }
         throw new IllegalStateException("Can't find node before cursor");

--- a/src/main/java/com/mojang/brigadier/context/SuggestionContext.java
+++ b/src/main/java/com/mojang/brigadier/context/SuggestionContext.java
@@ -6,10 +6,12 @@ package com.mojang.brigadier.context;
 import com.mojang.brigadier.tree.CommandNode;
 
 public class SuggestionContext<S> {
+    public final CommandContextBuilder<S> context;
     public final CommandNode<S> parent;
     public final int startPos;
 
-    public SuggestionContext(CommandNode<S> parent, int startPos) {
+    public SuggestionContext(CommandContextBuilder<S> context, CommandNode<S> parent, int startPos) {
+        this.context = context;
         this.parent = parent;
         this.startPos = startPos;
     }


### PR DESCRIPTION
This fixes [MC-278771](https://bugs.mojang.com/browse/MC-278771).

The overview of this issue is that `CommandDispatcher#getCompletionSuggestions` doesn't provide the correct `CommandContext` to the `CommandNode` for which it's listing suggestions from. This is an issue as some suggestions may be contextual and rely on previous arguments in the command tree. Currently the root `CommandContext` is provided, this means that any redirect causes the incorrect context to be provided and thus an `IllegalStateException` to be thrown as the argument cannot be found.

The solution to this is to provide the correct `CommandContextBuilder` in the `CommandContextBuilder#findSuggestionContext` method. This builder can then provide the correct `CommandContext` for the respective command node.