### PR TITLE
Don't suggest nodes which the source does not have requirements for

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -525,6 +525,7 @@ public class CommandDispatcher<S> {
 
     public CompletableFuture<Suggestions> getCompletionSuggestions(final ParseResults<S> parse, int cursor) {
         final CommandContextBuilder<S> context = parse.getContext();
+        S source = context.getSource();
 
         final SuggestionContext<S> nodeBeforeCursor = context.findSuggestionContext(cursor);
         final CommandNode<S> parent = nodeBeforeCursor.parent;
@@ -537,9 +538,11 @@ public class CommandDispatcher<S> {
         int i = 0;
         for (final CommandNode<S> node : parent.getChildren()) {
             CompletableFuture<Suggestions> future = Suggestions.empty();
-            try {
-                future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start));
-            } catch (final CommandSyntaxException ignored) {
+            if (node.canUse(source)) {
+                try {
+                    future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start));
+                } catch (final CommandSyntaxException ignored) {
+                }
             }
             futures[i++] = future;
         }

--- a/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandSuggestionsTest.java
@@ -313,4 +313,22 @@ public class CommandSuggestionsTest {
         assertThat(result.getRange(), equalTo(StringRange.at(18)));
         assertThat(result.getList(), equalTo(Lists.newArrayList(new Suggestion(StringRange.at(18), "bar"), new Suggestion(StringRange.at(18), "baz"))));
     }
+
+    @Test
+    public void getCompletionSuggestions_unmetRequirement() throws Exception {
+        subject.register(
+            literal("parent")
+                .then(
+                    literal("invalid").requires(o -> false)
+                )
+                .then(
+                    literal("valid")
+                )
+        );
+
+        final ParseResults<Object> parse = subject.parse("parent ", source);
+        final Suggestions result = subject.getCompletionSuggestions(parse).join();
+
+        assertThat(result.getList(), equalTo(Lists.newArrayList(new Suggestion(StringRange.at(7), "valid"))));
+    }
 }


### PR DESCRIPTION
Right now, requirements are not checked when generating suggestions. This means that the following test fails:

```java
// Added to `CommandSuggestionsTest`
@Test
public void getCompletionSuggestions_unmetRequirement() throws Exception {
    subject.register(
        literal("parent")
            .then(
                literal("invalid").requires(o -> false)
            )
            .then(
                literal("valid")
            )
    );

    final ParseResults<Object> parse = subject.parse("parent ", source);
    final Suggestions result = subject.getCompletionSuggestions(parse).join();

    // java.lang.AssertionError: 
    //  Expected: <[Suggestion{range=StringRange{start=7, end=7}, text='valid', tooltip='null'}]>
    //  but: was <[Suggestion{range=StringRange{start=7, end=7}, text='invalid', tooltip='null'}, 
    //  Suggestion{range=StringRange{start=7, end=7}, text='valid', tooltip='null'}]>
    assertThat(result.getList(), equalTo(Lists.newArrayList(new Suggestion(StringRange.at(7), "valid"))));
}
```

Since the `invalid` literal was given the requirement `o -> false`, the source cannot execute that node or any of its children. However, `invalid` is still given as a suggestion. Since the source is not allowed to use this node, it should not have it suggested, since that confusingly suggests it could work.

This PR fixes this issue by ignoring a node's suggestions if the source does not meet its requirements.