### PR TITLE
fix: CommandDispatcher.getPath should return a List

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -583,7 +583,7 @@ public class CommandDispatcher<S> {
      * @param target the target node you are finding a path for
      * @return a path to the resulting node, or an empty list if it was not found
      */
-    public Collection<String> getPath(final CommandNode<S> target) {
+    public List<String> getPath(final CommandNode<S> target) {
         final List<List<CommandNode<S>>> nodes = new ArrayList<>();
         addPaths(root, nodes, new ArrayList<>());
 


### PR DESCRIPTION
The return of this method is ordered, so it should be `List` instead of `Collection`.