### PR TITLE
Don't let an impermissible literal shadow an overlapping argument node

### DIFF
--- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
+++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
@@ -297,7 +297,7 @@ public class CommandDispatcher<S> {
         List<ParseResults<S>> potentials = null;
         final int cursor = originalReader.getCursor();
 
-        for (final CommandNode<S> child : node.getRelevantNodes(originalReader)) {
+        for (final CommandNode<S> child : node.getRelevantNodes(originalReader, source)) {
             if (!child.canUse(source)) {
                 continue;
             }

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -152,21 +152,32 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
 
     public Collection<? extends CommandNode<S>> getRelevantNodes(final StringReader input) {
         if (literals.size() > 0) {
-            final int cursor = input.getCursor();
-            while (input.canRead() && input.peek() != ' ') {
-                input.skip();
-            }
-            final String text = input.getString().substring(cursor, input.getCursor());
-            input.setCursor(cursor);
-            final LiteralCommandNode<S> literal = literals.get(text);
+            final LiteralCommandNode<S> literal = getMatchingLiteral(input);
             if (literal != null) {
                 return Collections.singleton(literal);
-            } else {
-                return arguments.values();
             }
-        } else {
-            return arguments.values();
         }
+        return arguments.values();
+    }
+
+    public Collection<? extends CommandNode<S>> getRelevantNodes(final StringReader input, final S source) {
+        if (literals.size() > 0) {
+            final LiteralCommandNode<S> literal = getMatchingLiteral(input);
+            if (literal != null && literal.canUse(source)) {
+                return Collections.singleton(literal);
+            }
+        }
+        return arguments.values();
+    }
+
+    private LiteralCommandNode<S> getMatchingLiteral(final StringReader input) {
+        final int cursor = input.getCursor();
+        while (input.canRead() && input.peek() != ' ') {
+            input.skip();
+        }
+        final String text = input.getString().substring(cursor, input.getCursor());
+        input.setCursor(cursor);
+        return literals.get(text);
     }
 
     @Override

--- a/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
+++ b/src/test/java/com/mojang/brigadier/CommandDispatcherTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 
 import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
 import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
+import static com.mojang.brigadier.arguments.StringArgumentType.word;
 import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static com.mojang.brigadier.builder.RequiredArgumentBuilder.argument;
 import static org.hamcrest.Matchers.equalTo;
@@ -121,6 +122,37 @@ public class CommandDispatcherTest {
             assertThat(ex.getType(), is(CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand()));
             assertThat(ex.getCursor(), is(0));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testImpermissibleLiteralFallsBackToArgument() throws Exception {
+        final Command<Object> argCommand = mock(Command.class);
+        when(argCommand.run(any())).thenReturn(100);
+        subject.register(literal("foo")
+                .then(literal("bar").requires(s -> false).executes(command))
+                .then(argument("value", word()).executes(argCommand)));
+
+        // The source cannot use the "bar" literal, so "foo bar" must fall back to the <value> argument
+        // instead of failing because the impermissible literal shadowed it.
+        assertThat(subject.execute("foo bar", source), is(100));
+        verify(argCommand).run(any(CommandContext.class));
+        verify(command, never()).run(any(CommandContext.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUsableLiteralTakesPriorityOverArgument() throws Exception {
+        final Command<Object> argCommand = mock(Command.class);
+        when(argCommand.run(any())).thenReturn(100);
+        subject.register(literal("foo")
+                .then(literal("bar").executes(command))
+                .then(argument("value", word()).executes(argCommand)));
+
+        // "bar" matches a usable literal, which must keep priority over the overlapping <value> argument.
+        assertThat(subject.execute("foo bar", source), is(42));
+        verify(command).run(any(CommandContext.class));
+        verify(argCommand, never()).run(any(CommandContext.class));
     }
 
     @Test


### PR DESCRIPTION
`CommandNode#getRelevantNodes` short-circuits to a literal as soon as its name matches the next token, without considering whether the source can use it:

```java
final LiteralCommandNode<S> literal = literals.get(text);
if (literal != null) {
  return Collections.singleton(literal);
} else {
  return arguments.values();
}
```

`parseNodes` then filters that node out with canUse(source) and moves on:

```java
for (final CommandNode<S> child : node.getRelevantNodes(originalReader)) {
  if (!child.canUse(source)) {
      continue;
  }
  // ...
}
```

Because the relevant-node set was the matched literal alone, there is nothing to fall back to; the argument siblings are never tried. So if a literal (e.g. bar, gated behind `requires(...)`) sits next to an argument node whose text overlaps it (e.g. <value>), a source that can't use bar can't reach <value> either, even though the argument would happily accept the input. A permission-gated literal silently makes an overlapping argument unreachable.

### Fix

Add a source-aware `getRelevantNodes(StringReader, S source)` overload that only short-circuits to the matched literal when the source can actually use it; otherwise it falls back to the argument nodes. `parseNodes` now calls this overload.

```java
public Collection<? extends CommandNode<S>> getRelevantNodes(final StringReader input, final S source) {
  if (literals.size() > 0) {
      final LiteralCommandNode<S> literal = getMatchingLiteral(input);
      if (literal != null && literal.canUse(source)) {
          return Collections.singleton(literal);
      }
  }
  return arguments.values();
}
```

The crucial property: when the literal is usable, the result is identical to before (`singleton(literal)`), so literal priority and the short-circuit are fully preserved. The fallback only kicks in for the shadowing case. This avoids the regression that "always return literal + arguments" would cause, where e.g. a greedy-string sibling could start beating a previously-prioritised literal in the potentials sort.