### PR TITLE
Refuse to merge a forwarding node in addChild instead of dropping its redirect

### DIFF
--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -72,7 +72,12 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
 
         final CommandNode<S> child = children.get(node.getName());
         if (child != null) {
-            // We've found something to merge onto
+            // We've found something to merge onto. Only the command and grandchildren are carried over;
+            // redirect/modifier/fork are final and cannot be merged in place, so refuse to merge when either
+            // side declares them rather than silently dropping that forwarding behavior.
+            if (isForwarding(node) || isForwarding(child)) {
+                throw new IllegalArgumentException("Cannot merge a node '" + node.getName() + "' that redirects or forks, as its redirect/modifier/fork would be lost");
+            }
             if (node.getCommand() != null) {
                 child.command = node.getCommand();
             }
@@ -87,6 +92,10 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
                 arguments.put(node.getName(), (ArgumentCommandNode<S, ?>) node);
             }
         }
+    }
+
+    private boolean isForwarding(final CommandNode<S> node) {
+        return node.getRedirect() != null || node.getRedirectModifier() != null || node.isFork();
     }
 
     public void findAmbiguities(final AmbiguityConsumer<S> consumer) {

--- a/src/test/java/com/mojang/brigadier/tree/AbstractCommandNodeTest.java
+++ b/src/test/java/com/mojang/brigadier/tree/AbstractCommandNodeTest.java
@@ -13,6 +13,7 @@ import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class AbstractCommandNodeTest {
@@ -66,5 +67,45 @@ public abstract class AbstractCommandNodeTest {
         node.addChild(literal("child").executes(command).build());
 
         assertThat(node.getChildren().iterator().next().getCommand(), is(command));
+    }
+
+    @Test
+    public void testAddChildAllowsNonMergingRedirect() throws Exception {
+        final CommandNode<Object> node = getCommandNode();
+        final CommandNode<Object> target = literal("target").build();
+
+        node.addChild(literal("child").redirect(target).build());
+
+        assertThat(node.getChildren(), hasSize(1));
+    }
+
+    @Test
+    public void testAddChildRefusesToMergeRedirect() throws Exception {
+        final CommandNode<Object> node = getCommandNode();
+        final CommandNode<Object> target = literal("target").build();
+
+        node.addChild(literal("child").build());
+
+        try {
+            // Merging a redirect onto an existing child would silently drop the redirect.
+            node.addChild(literal("child").redirect(target).build());
+            fail();
+        } catch (final IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testAddChildRefusesToMergeOntoRedirect() throws Exception {
+        final CommandNode<Object> node = getCommandNode();
+        final CommandNode<Object> target = literal("target").build();
+
+        node.addChild(literal("child").redirect(target).build());
+
+        try {
+            // Merging onto a redirect leaf would carry grandchildren onto a forwarding node.
+            node.addChild(literal("child").build());
+            fail();
+        } catch (final IllegalArgumentException expected) {
+        }
     }
 }


### PR DESCRIPTION
`CommandNode#addChild` merges onto an existing same-named child by carrying over only the command and grandchildren:

```java
final CommandNode<S> child = children.get(node.getName());
if (child != null) {
  // We've found something to merge onto
  if (node.getCommand() != null) {
      child.command = node.getCommand();
  }
  for (final CommandNode<S> grandchild : node.getChildren()) {
      child.addChild(grandchild);
  }
}
```

The incoming node's `redirect`, `modifier` and `forks` are `final`, so they're not merged, they're silently dropped. Registering a redirecting/forking literal under a name that's already present therefore yields a node that quietly loses its forwarding behavior (or, the reverse, grandchildren get merged onto an existing redirect leaf which the builder itself forbids via `then()`).

A genuine field-level merge isn't viable: `requirement` defaults to a fresh `s -> true` lambda on every builder and can't be compared, so an equality-based conflict check would also break the legitimate grandchild-merge case (`testAddChildMergesGrandchildren`). `redirect`/`modifier`/`forks` are different; they default to `null`/`null`/`false` and are only set deliberately through `forward()`, and the builder already treats forwarding and children as mutually exclusive (`then()` and `forward()` both throw).

So `addChild` now fails fast when a merge would involve a forwarding node on either side, mirroring those existing builder guards, instead of silently discarding the config:

```java
if (isForwarding(node) || isForwarding(child)) {
  throw new IllegalArgumentException("Cannot merge a node '" + node.getName()
      + "' that redirects or forks, as its redirect/modifier/fork would be lost");
}

private boolean isForwarding(final CommandNode<S> node) {
  return node.getRedirect() != null || node.getRedirectModifier() != null || node.isFork();
}
```

Adding a redirect/fork as a brand-new child (the normal case) is unchanged.